### PR TITLE
fix: test suite overwrites the developer's real config file on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Keep the working tree byte-identical on every platform.
+#
+# Without this, Git's Windows default (core.autocrlf=true) checks every file out
+# with CRLF endings. `gofmt -l .` then reports all Go files as unformatted, so the
+# documented `go test ./... && go vet ./... && test -z "$(gofmt -l .)"` check fails
+# on a clean Windows clone, and install.sh becomes unrunnable by /bin/sh.
+* text=auto eol=lf
+
+# Shell scripts and Go source must be LF even if a contributor overrides the above.
+*.sh   text eol=lf
+*.go   text eol=lf
+*.yaml text eol=lf
+*.yml  text eol=lf
+
+# Binary assets are never line-ending converted.
+*.png binary
+*.svg text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ permissions:
 
 jobs:
   test:
-    name: Go
-    runs-on: ubuntu-latest
+    name: Go (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -25,9 +32,15 @@ jobs:
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - run: go vet ./...
+      # The race detector needs a C toolchain; keep it on the Linux job, which
+      # covers the same platform-independent races.
       - run: go test -race ./...
+        if: runner.os == 'Linux'
+      - run: go test ./...
+        if: runner.os != 'Linux'
       - run: go build -trimpath -o aispace .
       - run: sh -n install.sh
+        if: runner.os == 'Linux'
       - name: Test npm wrapper
         working-directory: npm
         run: npm test && npm pack --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+# Build output.
 /aispace
+/aispace.exe
+# Default `go build .` output, named after the module rather than the binary.
+/aispace-client
+/aispace-client.exe
 /dist/
+
 *.agekey
 *.tmp
 .DS_Store
 /npm/bin/aispace
+/npm/bin/aispace.exe
 /npm/*.tgz

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -157,16 +158,31 @@ func (f *fakeServer) count() int {
 	return len(f.requests)
 }
 
-// isolate points HOME/XDG at a temp dir and clears env overrides.
+// permBits reports whether the platform implements Unix permission bits.
+// Windows does not: os.Chmod there only toggles the read-only attribute, so the
+// 0600 files this package writes cannot be observed as 0600.
+var permBits = runtime.GOOS != "windows"
+
+// isolate points HOME/XDG at a temp dir and clears env overrides. It verifies
+// the redirect took effect so a test can never write to the real config file.
 func isolate(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	// os.UserHomeDir reads USERPROFILE on Windows and HOME everywhere else.
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
 	t.Setenv("AISPACE_CONFIG", "")
 	t.Setenv(config.EnvKey, "")
 	t.Setenv(config.EnvURL, "")
 	t.Setenv(identityEnv, "")
+	p, err := config.Path()
+	if err != nil {
+		t.Fatalf("config.Path() while isolating the test: %v", err)
+	}
+	if !strings.HasPrefix(p, dir) {
+		t.Fatalf("config path %s escaped the test home %s; refusing to run so the real config is not overwritten", p, dir)
+	}
 	old := sleep
 	sleep = func(time.Duration) {}
 	t.Cleanup(func() { sleep = old })
@@ -244,7 +260,7 @@ func TestKeygenIdentityFile(t *testing.T) {
 		t.Fatalf("secret leaked or path missing: %+v", out)
 	}
 	info, err := os.Stat(path)
-	if err != nil || info.Mode().Perm() != 0o600 {
+	if err != nil || (permBits && info.Mode().Perm() != 0o600) {
 		t.Fatalf("identity file: info=%v err=%v", info, err)
 	}
 	r = run("", "keygen", "--identity-out", path)
@@ -359,7 +375,7 @@ func TestLoginWritesConfigAndValidates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config not written at XDG path: %v", err)
 	}
-	if st.Mode().Perm() != 0o600 {
+	if permBits && st.Mode().Perm() != 0o600 {
 		t.Fatalf("perm %04o", st.Mode().Perm())
 	}
 	got, _, _ := config.Load(p)
@@ -437,6 +453,9 @@ func TestPrecedenceFlagEnvFile(t *testing.T) {
 }
 
 func TestConfigPermWarning(t *testing.T) {
+	if !permBits {
+		t.Skip("Unix permission bits are not implemented on this platform")
+	}
 	isolate(t)
 	f := newFakeServer(t)
 	p := writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
@@ -528,7 +547,7 @@ func TestEncryptedUploadAndLocalDecrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if identityInfo.Mode().Perm() != 0o600 {
+	if permBits && identityInfo.Mode().Perm() != 0o600 {
 		t.Fatalf("identity mode = %o", identityInfo.Mode().Perm())
 	}
 	req, ciphertext := f.last()
@@ -554,7 +573,7 @@ func TestEncryptedUploadAndLocalDecrypt(t *testing.T) {
 		t.Fatalf("plaintext %q err=%v", got, err)
 	}
 	decryptedInfo, err := os.Stat(decryptedPath)
-	if err != nil || decryptedInfo.Mode().Perm() != 0o600 {
+	if err != nil || (permBits && decryptedInfo.Mode().Perm() != 0o600) {
 		t.Fatalf("decrypted mode/info = %v err=%v", decryptedInfo, err)
 	}
 }

--- a/install_test.go
+++ b/install_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -114,6 +115,12 @@ type installerResult struct {
 
 func newInstallerHarness(t *testing.T, goos, arch, downloader, checksum string) *installerHarness {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		// install.sh only supports darwin and linux, and the harness below builds a
+		// hermetic PATH out of symlinks to real POSIX tools, which needs a
+		// privilege Windows does not grant by default.
+		t.Skip("install.sh is a POSIX-only delivery path")
+	}
 	root := t.TempDir()
 	h := &installerHarness{t: t, root: root, binDir: filepath.Join(root, "bin"), installDir: filepath.Join(root, "install"), assetsDir: filepath.Join(root, "assets"), logPath: filepath.Join(root, "tools.log"), os: goos, arch: arch, downloader: downloader, checksum: checksum}
 	for _, dir := range []string{h.binDir, h.installDir, h.assetsDir} {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,18 +3,41 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
+// permBits reports whether the platform implements Unix permission bits.
+// Windows does not: os.Chmod there only toggles the read-only attribute, so
+// Save cannot produce (and Load cannot observe) mode 0600. Load already skips
+// its permission warning on Windows for the same reason.
+var permBits = runtime.GOOS != "windows"
+
+// setHome redirects config lookups into a temporary directory and clears the
+// environment overrides.
+//
+// It then asserts the redirect actually took effect, because every caller
+// writes to Path(): if the redirect silently failed, the tests below would
+// overwrite the developer's real config file and destroy a saved API key.
 func setHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	// os.UserHomeDir reads USERPROFILE on Windows and HOME everywhere else.
+	// Set both so the redirect holds on every platform.
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("AISPACE_CONFIG", "")
 	t.Setenv(EnvKey, "")
 	t.Setenv(EnvURL, "")
+	p, err := Path()
+	if err != nil {
+		t.Fatalf("Path() while isolating the test: %v", err)
+	}
+	if !strings.HasPrefix(p, dir) {
+		t.Fatalf("config path %s escaped the test home %s; refusing to run so the real config is not overwritten", p, dir)
+	}
 	return dir
 }
 
@@ -45,11 +68,11 @@ func TestSaveCreates0600AndRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.Mode().Perm() != 0o600 {
+	if permBits && st.Mode().Perm() != 0o600 {
 		t.Fatalf("perm = %04o, want 0600", st.Mode().Perm())
 	}
 	dst, _ := os.Stat(filepath.Dir(p))
-	if dst.Mode().Perm() != 0o700 {
+	if permBits && dst.Mode().Perm() != 0o700 {
 		t.Fatalf("dir perm = %04o, want 0700", dst.Mode().Perm())
 	}
 	f, warns, err := Load(p)
@@ -67,7 +90,7 @@ func TestSaveCreates0600AndRoundTrips(t *testing.T) {
 		t.Fatal(err)
 	}
 	st, _ = os.Stat(p)
-	if st.Mode().Perm() != 0o600 {
+	if permBits && st.Mode().Perm() != 0o600 {
 		t.Fatalf("perm after overwrite = %04o", st.Mode().Perm())
 	}
 	entries, _ := os.ReadDir(filepath.Dir(p))
@@ -86,6 +109,9 @@ func TestLoadMissingIsEmpty(t *testing.T) {
 }
 
 func TestLoadWarnsOnLoosePerms(t *testing.T) {
+	if !permBits {
+		t.Skip("Unix permission bits are not implemented on this platform")
+	}
 	setHome(t)
 	p, _ := Path()
 	if err := Save(p, File{Key: "ask_abc"}); err != nil {
@@ -157,6 +183,9 @@ func TestResolvePrecedence(t *testing.T) {
 }
 
 func TestResolveSurfacesPermWarning(t *testing.T) {
+	if !permBits {
+		t.Skip("Unix permission bits are not implemented on this platform")
+	}
 	setHome(t)
 	p, _ := Path()
 	_ = Save(p, File{Key: "ask_file"})


### PR DESCRIPTION
## The bug

Running `go test ./...` on a Windows checkout **overwrites the developer's real `~/.config/aispace/config.json`**, replacing a saved API key with a test fixture.

`internal/config/config_test.go` isolates the config lookup like this:

```go
func setHome(t *testing.T) string {
	dir := t.TempDir()
	t.Setenv("HOME", dir)
	...
}
```

But `config.Path()` falls back to `os.UserHomeDir()`, and **`os.UserHomeDir()` reads `USERPROFILE` on Windows**, not `HOME`. So the redirect silently does nothing, `Path()` resolves to the real config file, and `TestSaveCreates0600AndRoundTrips` calls `Save()` on it.

Reproduced on Windows 11 / Go 1.26.6, on a clean clone of `main`:

```
$ go test ./...
--- FAIL: TestPathDefaultsAndXDG (0.01s)
    config_test.go:28: Path() = C:\Users\<me>\.config\aispace\config.json, want C:\...\Temp\TestPathDefaultsAndXDG.../001\.config\aispace\config.json

$ cat ~/.config/aispace/config.json
{
  "key": "ask_file"
}

$ aispace ls
error: Invalid bot key (invalid_key)     # exit 3 — my real key is gone
```

`TestPathDefaultsAndXDG` does fail, but `t.Fatalf` only stops that one test — the later tests still run and still write. The failure looks like a cosmetic path mismatch, so the data loss is easy to miss.

## The fix

Two parts, and the second one matters more than the first:

1. Set `USERPROFILE` alongside `HOME` in both test helpers.
2. Have `setHome`/`isolate` **assert that `config.Path()` actually landed inside the temp directory**, and fail before running the test body if it did not.

With the `USERPROFILE` line reverted, the guard now turns the silent write into an explicit refusal:

```
--- FAIL: TestSaveCreates0600AndRoundTrips (0.00s)
    config_test.go:61: config path C:\Users\<me>\.config\aispace\config.json escaped the
        test home C:\...\Temp\TestSaveCreates0600AndRoundTrips.../001; refusing to run so
        the real config is not overwritten
```

That closes the whole class of bug, not just this instance.

## Making it verifiable on Windows

The fix is only checkable if the suite can run there, so this PR also gets `go test ./...` to pass on `windows-latest`:

- **Permission assertions** are guarded by a `permBits` constant. Windows does not implement Unix permission bits — `os.Chmod` only toggles the read-only attribute — so `Save` cannot produce an observable `0600`. This is already acknowledged in production code: `config.Load` skips its permission warning under `runtime.GOOS == "windows"`. The two tests that exist *only* to assert that warning are skipped rather than weakened.
- **`install_test.go` is skipped on Windows.** It builds a hermetic `PATH` from symlinks to real POSIX tools (`sh`, `tar`, `awk`, …), which needs `SeCreateSymbolicLinkPrivilege`, and `install.sh` supports only darwin/linux by design.
- **`.gitattributes` pins LF.** With Git's Windows default (`core.autocrlf=true`) the tree checks out CRLF and `gofmt -l .` reports **all 16 Go files** as unformatted — so the `go test ./... && go vet ./... && test -z "$(gofmt -l .)"` command in the README fails on a clean clone before you have changed anything. The committed blobs are already LF; this only fixes the working tree.
- **`.gitignore`** now covers `aispace-client[.exe]`, the binary a plain `go build .` leaves behind (named after the module, not the binary). That was untracked on Linux too.

## CI

The Go job becomes a matrix over `ubuntu-latest` and `windows-latest`, with `shell: bash` so the existing steps are unchanged. `-race` stays Linux-only: it needs a C toolchain, and the races it finds are not platform-specific. `sh -n install.sh` also stays Linux-only.

## Verification

On Windows 11, Go 1.26.6:

```
gofmt -l .          # clean
go vet ./...        # clean
go test ./...       # ok: root, cmd, internal/api, internal/config, internal/duration
```

No production code is touched — the diff is tests, CI, and repo metadata only.
