### PR TITLE
fix(duration): reject out-of-range durations instead of silently wrapping

### DIFF
--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -4,6 +4,7 @@ package duration
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -18,18 +19,27 @@ func Parse(s string) (time.Duration, error) {
 		return 0, errors.New("empty duration")
 	}
 	if secs, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return check(time.Duration(secs) * time.Second)
+		d, ok := scale(secs, time.Second)
+		if !ok {
+			return 0, rangeError(s)
+		}
+		return check(d)
 	}
 	if i := strings.IndexByte(s, 'd'); i > 0 {
 		days, err := strconv.ParseInt(s[:i], 10, 64)
 		if err == nil {
-			d := time.Duration(days) * 24 * time.Hour
+			d, ok := scale(days, 24*time.Hour)
+			if !ok {
+				return 0, rangeError(s)
+			}
 			if rest := s[i+1:]; rest != "" {
 				more, err := time.ParseDuration(rest)
 				if err != nil {
 					return 0, fmt.Errorf("invalid duration %q", s)
 				}
-				d += more
+				if d, ok = add(d, more); !ok {
+					return 0, rangeError(s)
+				}
 			}
 			return check(d)
 		}
@@ -59,4 +69,32 @@ func check(d time.Duration) (time.Duration, error) {
 		return 0, errors.New("duration must be positive")
 	}
 	return d, nil
+}
+
+// scale converts n units of size unit into a time.Duration, reporting false if
+// the product does not fit. A time.Duration is int64 nanoseconds, so it spans
+// only about 292 years; without this check "1000000000000d" wrapped around to a
+// positive 225-year value and was accepted as valid.
+func scale(n int64, unit time.Duration) (time.Duration, bool) {
+	if n == 0 {
+		return 0, true
+	}
+	limit := int64(math.MaxInt64) / int64(unit)
+	if n > limit || n < -limit {
+		return 0, false
+	}
+	return time.Duration(n) * unit, true
+}
+
+// add sums two durations, reporting false when the result wraps.
+func add(a, b time.Duration) (time.Duration, bool) {
+	sum := a + b
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		return 0, false
+	}
+	return sum, true
+}
+
+func rangeError(s string) error {
+	return fmt.Errorf("duration %q is out of range (the maximum is about 106751d)", s)
 }

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -1,6 +1,7 @@
 package duration
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -25,6 +26,15 @@ func TestParse(t *testing.T) {
 		{"1dx", 0, true},
 		{"d", 0, true},
 		{"1.5d", 0, true},
+		// Largest values that still fit in an int64 nanosecond duration, and the
+		// first ones past the edge. These used to wrap around silently.
+		{"9223372036", 9223372036 * time.Second, false},
+		{"9223372037", 0, true},
+		{"106751d", 106751 * 24 * time.Hour, false},
+		{"106752d", 0, true},
+		{"1000000000000d", 0, true},
+		{"106751d23h", 2562047 * time.Hour, false},
+		{"106751d24h", 0, true},
 	}
 	for _, c := range cases {
 		got, err := Parse(c.in)
@@ -53,5 +63,32 @@ func TestSeconds(t *testing.T) {
 	}
 	if _, err := Seconds("nope"); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// A duration too large for time.Duration must be rejected rather than wrapping
+// around into a small positive value. "1000000000000d" used to parse as roughly
+// 225 years and be sent to the server as a valid X-Expires-In.
+func TestParseRejectsOverflowInsteadOfWrapping(t *testing.T) {
+	for _, in := range []string{"1000000000000d", "9223372036854775807", "10000000000", "106752d"} {
+		got, err := Parse(in)
+		if err == nil {
+			t.Errorf("Parse(%q) = %v, want an error", in, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Errorf("Parse(%q) error = %q, want it to mention the range", in, err)
+		}
+	}
+}
+
+// Overflow must not be reported as a sign problem: the old code only noticed
+// wrapped values when they happened to land on a non-positive number.
+func TestParseDistinguishesOverflowFromNonPositive(t *testing.T) {
+	if _, err := Parse("0"); err == nil || !strings.Contains(err.Error(), "positive") {
+		t.Errorf("Parse(0) error = %v, want a positive-value error", err)
+	}
+	if _, err := Seconds("1000000000000d"); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("Seconds overflow error = %v, want an out-of-range error", err)
 	}
 }


### PR DESCRIPTION
## The bug

`time.Duration` is int64 nanoseconds, so it only spans about 292 years. `Parse` multiplied the parsed number by its unit without checking the product, so a large value wrapped around silently instead of being rejected:

```
Parse("1000000000000d") = 1973480h44m26.489905152s, err = <nil>
```

That is roughly 225 years, accepted as a valid duration. So:

```sh
aispace upload report.pdf --expires 1000000000000d
```

sends an arbitrary `X-Expires-In` to the server instead of failing with the exit-2 usage error the docs promise for an unparsable duration. The value the user asked for and the value the client sends are unrelated.

## Why the existing guard missed it

`check()` rejects non-positive durations, and that caught *most* overflows — but only by accident. A wrapped value usually lands on a negative number and trips `duration must be positive`, which is:

- **a misleading message** for an out-of-range input (`Parse("9223372036854775807")` reports a sign problem, not a range problem), and
- **an incomplete guard**, because a wrapped value can just as easily land on a positive number. That is exactly the `1000000000000d` case, which sails through.

## The fix

Multiply through `scale()`, which compares against `MaxInt64/unit` before multiplying, and sum the `1d12h` form through `add()`, which detects a wrapped total. Both report an explicit error naming the real limit:

```
duration "1000000000000d" is out of range (the maximum is about 106751d)
```

No behaviour changes for any value that previously parsed correctly.

## Tests

The new cases pin both edges rather than just testing a big number:

| Input | Expected |
|---|---|
| `9223372036` | largest whole-second value that fits — still parses |
| `9223372037` | one second past — error |
| `106751d` | largest whole-day value that fits — still parses |
| `106752d` | one day past — error |
| `106751d23h` | the `Nd` + Go-duration form, just inside the limit — still parses |
| `106751d24h` | same form, addition overflows — error |
| `1000000000000d` | the value that used to wrap to a positive result |

Plus two named tests: one asserting overflow is rejected with an out-of-range message, and one asserting overflow is *distinguished* from the non-positive case, so the two failure modes cannot be conflated again.

Verified they are real regression tests — against the current `duration.go` they fail:

```
--- FAIL: TestParse
    duration_test.go:43: Parse("1000000000000d") = 1973480h44m26.489905152s, want error
--- FAIL: TestParseRejectsOverflowInsteadOfWrapping
    duration_test.go:80: Parse("9223372036854775807") error = "duration must be positive", want it to mention the range
--- FAIL: TestParseDistinguishesOverflowFromNonPositive
    duration_test.go:92: Seconds overflow error = <nil>, want an out-of-range error
```

and with the fix applied, `go test ./internal/duration/` passes. `go vet ./...` is clean and both changed files are `gofmt`-clean.
