### PR TITLE
fix: control characters in key/name/content-type exit 1 as a network fault instead of 2

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1128,3 +1128,90 @@ func TestFmtBytes(t *testing.T) {
 		}
 	}
 }
+
+// A control character in any value that becomes an HTTP header used to reach
+// the transport, which failed with "invalid header field value". That surfaced
+// as exit 1 with code "network", telling an agent to retry a request that can
+// never succeed. All of these are bad input and must exit 2.
+func TestControlCharactersInHeaderValuesAreUsageErrors(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+	path := filepath.Join(t.TempDir(), "ok.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"name with newline", []string{"upload", path, "--name", "a\nb.txt"}, "file name must not contain control characters"},
+		{"name with CR", []string{"upload", path, "--name", "a\rb.txt"}, "file name must not contain control characters"},
+		{"content type with newline", []string{"upload", path, "--content-type", "text/x\ny"}, "--content-type must not contain control characters"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := run("", c.args...)
+			if r.code != ExitUsage {
+				t.Fatalf("exit = %d, want %d: %+v", r.code, ExitUsage, r)
+			}
+			if !strings.Contains(r.stderr, c.want) {
+				t.Fatalf("stderr = %q, want it to contain %q", r.stderr, c.want)
+			}
+			if strings.Contains(r.stderr, "network") {
+				t.Fatalf("bad input reported as a network fault: %q", r.stderr)
+			}
+		})
+	}
+	if f.count() != 0 {
+		t.Fatalf("no request should have been sent, got %d", f.count())
+	}
+}
+
+// A key read from a file often keeps a trailing newline, and on Windows a CRLF
+// file leaves a \r. That cannot go into an Authorization header.
+func TestControlCharacterInKeyIsUsageError(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	t.Setenv(config.EnvURL, f.srv.URL)
+
+	for _, suffix := range []string{"\n", "\r", "\r\n"} {
+		key := f.key + suffix
+		t.Setenv(config.EnvKey, key)
+		for _, cmd := range []string{"quota", "ls", "whoami", "login"} {
+			r := run("", cmd)
+			if r.code != ExitUsage {
+				t.Errorf("%s with key%q: exit = %d, want %d (%+v)", cmd, suffix, r.code, ExitUsage, r)
+			}
+			if !strings.Contains(r.stderr, "control character") {
+				t.Errorf("%s with key%q: stderr = %q", cmd, suffix, r.stderr)
+			}
+			// The key is a credential and must not be echoed back.
+			if strings.Contains(r.stdout+r.stderr, f.key) {
+				t.Errorf("%s with key%q leaked the key: %q", cmd, suffix, r.stdout+r.stderr)
+			}
+		}
+	}
+	if f.count() != 0 {
+		t.Fatalf("no request should have been sent, got %d", f.count())
+	}
+}
+
+// Values that are unusual but legal in a header must keep working.
+func TestHeaderSafeValuesStillAccepted(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+	path := filepath.Join(t.TempDir(), "ok.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"café.txt", "a b.txt", "a\tb.txt", "sürprise-résumé.pdf"} {
+		r := run("", "upload", path, "--name", name)
+		if r.code != ExitOK {
+			t.Errorf("upload --name %q = %+v, want success", name, r)
+		}
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -35,6 +35,9 @@ func (a *app) loginCmd() *cobra.Command {
 			if !strings.HasPrefix(key, "ask_") {
 				return usagef("key must start with ask_")
 			}
+			if err := validateKey(key); err != nil {
+				return err
+			}
 			if err := validateServerURL(cfg.URL); err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -194,6 +194,9 @@ func (a *app) client() (*api.Client, error) {
 			exit: ExitAuth,
 		}
 	}
+	if err := validateKey(cfg.Key); err != nil {
+		return nil, err
+	}
 	if err := validateServerURL(cfg.URL); err != nil {
 		return nil, err
 	}
@@ -221,6 +224,41 @@ func validateServerURL(raw string) error {
 		return nil
 	}
 	return usagef("--url must use HTTPS (HTTP is allowed only for localhost)")
+}
+
+// invalidHeaderByte returns the index of the first byte that cannot appear in
+// an HTTP header value, or -1. It mirrors the check net/http applies when
+// writing a request: control characters are rejected, tab is allowed, and
+// bytes >= 0x80 are passed through.
+func invalidHeaderByte(v string) int {
+	for i := 0; i < len(v); i++ {
+		if b := v[i]; b < 0x20 && b != '	' || b == 0x7f {
+			return i
+		}
+	}
+	return -1
+}
+
+// validateHeaderValue rejects a value that cannot be sent as an HTTP header.
+// The transport would otherwise fail with "invalid header field value", which
+// reads as a network fault and exits 1, telling an agent to retry a request
+// that can never succeed. These are bad inputs, so they exit 2 instead.
+func validateHeaderValue(what, v string) error {
+	i := invalidHeaderByte(v)
+	if i < 0 {
+		return nil
+	}
+	return usagef("%s must not contain control characters: found %q at byte %d", what, v[i:i+1], i)
+}
+
+// validateKey checks the key before it becomes an Authorization header. The
+// message never echoes the key, which is a credential; a trailing newline is
+// the common cause, from a key file read whole or one with CRLF endings.
+func validateKey(key string) error {
+	if invalidHeaderByte(key) >= 0 {
+		return usagef("API key contains a control character (often a trailing newline from reading a key file); strip whitespace from --key, AISPACE_KEY or the config file")
+	}
+	return nil
 }
 
 // classify maps an error to (exit code, error code string).

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -124,6 +124,16 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 		}
 		ct = encryptedContentType
 	}
+	// Both values are sent as HTTP headers, so reject anything the transport
+	// would refuse. name may come from --name or from the file's basename, which
+	// on POSIX can legitimately contain a newline.
+	if err := validateHeaderValue("file name", name); err != nil {
+		return err
+	}
+	if err := validateHeaderValue("--content-type", ct); err != nil {
+		return err
+	}
+
 	opts := api.UploadOptions{Name: name, Size: size, ExpiresIn: expiresIn, ContentType: ct}
 	if f.private {
 		opts.Visibility = "private"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,7 +85,7 @@ the API's code and message together with the exit code, so a caller can branch o
 |---|---|---|
 | `0` | Success | |
 | `1` | Generic failure | Network error, 5xx, unexpected response, file not found locally |
-| `2` | Usage error | Bad flag, missing argument, unparsable duration |
+| `2` | Usage error | Bad flag, missing argument, unparsable duration, control character in the key, `--name` or `--content-type` |
 | `3` | Authentication | No key configured, `401 invalid_key`, `401 key_revoked` |
 | `4` | Quota | `402 quota_exceeded`, `402 allowance_exceeded`, `402 payment_required`, `413 file_too_large` |
 | `5` | Rate limited or monthly cap | `429 rate_limited` after the retry policy below gave up; `429 monthly_upload_cap` / `429 monthly_download_cap` (never retried — the reset is next month) |


### PR DESCRIPTION
## The bug

The key, the file name and the content type all travel as HTTP headers, and none was validated. A control character in any of them reaches the transport, which refuses to write the request:

```
$ AISPACE_KEY="$(cat key.txt)" aispace quota
error: Get https://aispace.sh/v1/quota: net/http: invalid header field value for "Authorization" (network)
$ echo $?
1
```

Exit 1 is documented as *"generic error (network, 4xx/5xx not listed below)"*. So an agent following the exit-code contract reads this as a transport fault and retries — but the request can never succeed, no matter how many times it is sent. The value is bad input, which is exit 2.

This matters more here than in a typical CLI, because stable exit codes are one of the four things the README sells:

> one binary, **stable exit codes**, machine-readable JSON, and optional local age encryption

All three input paths, reproduced against the fake server in `cmd/cmd_test.go`:

```
key with trailing CR (quota)    exit=1  invalid header field value for "Authorization" (network)
key with trailing LF (ls)       exit=1  invalid header field value for "Authorization" (network)
key with trailing CR (login)    exit=1  invalid header field value for "Authorization" (network)
--name with newline             exit=1  invalid header field value for "X-File-Name"    (network)
--content-type with newline     exit=1  invalid header field value for "Content-Type"   (network)
```

## How you actually hit it

- **A key that kept its trailing newline.** `AISPACE_KEY="$(cat key.txt)"` strips it, but reading the file any other way does not, and a key file saved with CRLF leaves a `\r` even through `$(...)`. Windows is a supported development platform since #2, and this is the shape the failure takes there.
- **A file name with a newline.** Legal in a POSIX filename, so `aispace upload "$f"` can trip on the basename alone — and `--name` is frequently built from other command output.
- **`--content-type`** as the third path.

The key case is the sharpest: nothing about `net/http: invalid header field value for "Authorization"` suggests "your key has a newline on the end", which is the one thing you need to know.

## The fix

Validate all three before the request is built, mirroring the `validateServerURL` check that already sits in `cmd/root.go`:

- `validateKey` is called from `app.client()` **and** from `login`, which builds its own client and would otherwise bypass it. Its message deliberately **does not echo the key** — it is a credential — and names the likely cause instead:
  ```
  error: API key contains a control character (often a trailing newline from reading a key file);
  strip whitespace from --key, AISPACE_KEY or the config file (usage)
  ```
- `validateHeaderValue` covers the **resolved** upload name — so a bad `--name` and a bad basename are both caught — and the content type, reporting the offending byte and its offset:
  ```
  error: file name must not contain control characters: found "\n" at byte 1 (usage)
  ```

`invalidHeaderByte` mirrors what `net/http` accepts rather than inventing a stricter rule: control characters rejected, tab allowed, bytes `>= 0x80` passed through. That last part matters — `café.txt`, `sürprise-résumé.pdf` and names containing tabs or spaces must keep working, and a test pins exactly that so this cannot quietly become an ASCII-only filename restriction.

I kept it in `cmd/` rather than `internal/api/` so the failures map to `usageError` → exit 2, consistent with how `--url` is already handled.

## Verification

The three new tests fail against `main` and pass with the fix:

```
--- FAIL: TestControlCharactersInHeaderValuesAreUsageErrors/name_with_newline
    exit = 1, want 2: ... invalid header field value for "X-File-Name" (network)
--- FAIL: TestControlCharacterInKeyIsUsageError
    quota with key"\n": exit = 1, want 2
```

They also assert two things beyond the exit code: that **no request is sent** (`f.count() == 0`), and that the key never appears in stdout or stderr.

`gofmt`, `go vet ./...` and `go test ./...` are clean on Windows and the change adds no dependency. One line of `docs/CLI.md` updated so the exit-2 row lists the new cause.
