### PR TITLE
docs: remove the non-existent quota.month object from the agent guide

### DIFF
--- a/docs/LLM_USAGE.md
+++ b/docs/LLM_USAGE.md
@@ -25,9 +25,12 @@ long or too structured for chat (reports, tables, code bundles, images).
   free plan and 30 days on Pro. Never promise permanence.
 - Before uploading anything large, or before a batch of uploads, run `aispace quota --json` and
   check `.limits.max_file_bytes`, `.key.remaining_bytes`, `.account.remaining_bytes` and the
-  monthly counters `.month.uploads_used` / `.month.uploads_limit`.
-- Exit codes: 4 = storage quota exceeded (tell the user, do not retry), 5 = rate limited or the
-  monthly cap is used up, 3 = key problem (stop and tell the user).
+  short-window counters `.rate.uploads_hour_remaining` / `.rate.uploads_day_remaining`.
+- The account-wide monthly cap is not reported by `quota`; it appears only as a `429` with code
+  `monthly_upload_cap` or `monthly_download_cap` when you hit it.
+- Exit codes: 2 = bad input, fix the arguments and do not retry unchanged; 3 = key problem (stop
+  and tell the user); 4 = storage quota exceeded (tell the user, do not retry); 5 = rate limited
+  or the monthly cap is used up.
 - If the error code is `monthly_upload_cap` or `monthly_download_cap` the account is out of
   requests for the whole calendar month: do NOT retry or wait, tell the user the cap is reached
   and that they can upgrade in the dashboard or mail contacts@aispace.sh.
@@ -222,7 +225,7 @@ still works until it expires or the agent runs `aispace revoke`.
 | Result the user will open right now | 1d | 15m–1h | 1–3 |
 | Report for a meeting later today | 3d | 8h | none |
 | Handoff to a third party by email | 7d (default) | 24h | 1 per recipient (mint one link each) |
-| Log bundle for a support ticket | 7d | 7d (the free-plan max; 30d on paid) | none |
+| Log bundle for a support ticket | 7d | 7d (links are Pro-only; capped at 30d and never past the file's expiry) | none |
 | Anything containing PII or credentials-adjacent data | 1d | 15m | 1 |
 | Intermediate artefact between two agents | 1h | 15m | 1 |
 
@@ -256,23 +259,24 @@ aispace quota --json | jq -e --argjson n "$need" '
   .limits.max_file_bytes >= $n
   and .key.remaining_bytes >= $n
   and .account.remaining_bytes >= $n
-  and (.month.uploads_limit - .month.uploads_used) > 0
   and .rate.uploads_hour_remaining > 0
   and .rate.uploads_day_remaining > 0' >/dev/null || { echo "cannot upload $need bytes now"; aispace quota; exit 4; }
 ```
 
-Before a **batch** of N uploads, check the count and the total bytes in one go — the monthly cap
-is account-wide (shared by every key), so a batch that fits in storage can still exhaust the
-month:
+Before a **batch** of N uploads, check the daily upload count and the total bytes in one go:
 
 ```sh
 n=250; total=52428800   # 250 files, 50 MB together
 aispace quota --json | jq -e --argjson n "$n" --argjson t "$total" '
-  (.month.uploads_limit - .month.uploads_used) >= $n
-  and .key.remaining_bytes >= $t
-  and .account.remaining_bytes >= $t' >/dev/null || {
+  .key.remaining_bytes >= $t
+  and .account.remaining_bytes >= $t
+  and .rate.uploads_day_remaining >= $n' >/dev/null || {
     echo "batch of $n would exceed a cap; see aispace quota"; exit 4; }
 ```
+
+The monthly cap cannot be pre-checked, so a batch that clears this check can still stop partway
+with `429 monthly_upload_cap`. Treat that as terminal for the month rather than retrying, and
+report how many of the N uploads completed.
 
 If the batch does not fit, prefer **one archive over many files** (`tar czf - dir | aispace upload
 - --name out.tgz`): it costs a single upload against the monthly cap instead of N. That is usually
@@ -288,7 +292,7 @@ What to tell the user for each failing term:
 | `limits.max_file_bytes < need` | File is over the per-file cap (5 MB on Free, 100 MB on Pro). Split it, compress it, or ask the human to upgrade. |
 | `key.remaining_bytes < need` | This key's budget is full. Delete old files (`aispace ls`, `aispace rm`) or ask the human to raise the budget in the dashboard. |
 | `account.remaining_bytes < need` | The account is at its storage allowance (10 MB on Free, 10 GB per Pro block). The human can free space or add a block. |
-| `month.uploads_used >= month.uploads_limit` | The account's monthly upload cap is used up (100 on Free, 10,000 per Pro block). Nothing will upload until `month.period_end`; tell the human to upgrade or mail contacts@aispace.sh. |
+| `429 monthly_upload_cap` (not pre-checkable) | The account's monthly upload cap is used up (100 on Free, 10,000 per Pro block). Nothing will upload until the next UTC month; tell the human to upgrade or mail contacts@aispace.sh. |
 | `rate.uploads_hour_remaining == 0` | Rate limited; wait until the top of the hour or batch outputs into one archive. |
 
 Every `/v1` response also carries `X-Quota-Remaining` (bytes left on the key), so a client that


### PR DESCRIPTION
Follow-up to #3, which removed the same references from `docs/CLI.md`. `docs/LLM_USAGE.md` still referenced a `quota.month` object in four places:

```
line  28  monthly counters `.month.uploads_used` / `.month.uploads_limit`
line 259  and (.month.uploads_limit - .month.uploads_used) > 0
line 271  (.month.uploads_limit - .month.uploads_used) >= $n
line 291  `month.uploads_used >= month.uploads_limit` ... until `month.period_end`
```

`Quota` in [`internal/api/types.go`](internal/api/types.go) has `key`, `account`, `limits` and `rate`. There is no `month`, and `docs/API.md` names that file "the executable client contract".

## Why this file is worse than CLI.md was

`CLI.md` is read. This file is **used verbatim**:

- The system-prompt snippet is designed to be pasted straight into an agent's prompt, so it teaches the agent to read counters that are not there.
- The two `jq -e` blocks are shipped as runnable shell.

And the `jq` blocks do not merely return a wrong answer — they refuse every upload:

```sh
aispace quota --json | jq -e '
  .limits.max_file_bytes >= $n
  ...
  and (.month.uploads_limit - .month.uploads_used) > 0
  ...' >/dev/null || { echo "cannot upload $need bytes now"; aispace quota; exit 4; }
```

`.month` is absent, so `.month.uploads_limit` evaluates to `null`, and `null - null` is a jq **error**, not a falsy value — jq exits non-zero. The snippet is written as `jq -e ... || { ... exit 4; }`, so the guard fires on that error and reports that the upload cannot proceed.

When the quota genuinely *is* exhausted, an earlier term is false, `and` short-circuits before reaching the broken term, and the guard fires too. So the documented pre-check reports "cannot upload" in both cases, and an agent that follows this guide never uploads at all — while appearing to fail for a legitimate quota reason.

I could not run `jq` in my environment to paste real output, so that is reasoning from jq's arithmetic-on-null behaviour rather than a captured transcript. The premise underneath it — that `month` is not in the contract — is the part I did verify, and it is the same one accepted in #3.

## Changes

- Replaced the monthly terms with `.rate.uploads_hour_remaining` and `.rate.uploads_day_remaining`, which exist in `Quota`.
- Said plainly that the account-wide monthly cap is **not** reported by `quota` and surfaces only as a `429` with `monthly_upload_cap` / `monthly_download_cap`. The failing-term table row was rewritten to match.
- The batch section now notes that a batch which clears the pre-check can still stop partway on the monthly cap, and that the agent should report how many of the N uploads completed — which is the behaviour that actually matters and was previously implied to be preventable.

Two smaller corrections while in the file:

- The system-prompt exit-code line listed 3, 4 and 5 but omitted **2** — the one an agent most needs, since it is the code that means *do not retry unchanged*. (Related: #6 makes several inputs correctly return 2 instead of 1.)
- The expiration table offered "7d (the free-plan max)" as a link lifetime. The README is explicit that creating a link requires Pro — "Maximum 30 days because links require Pro" — so there is no free-plan link maximum to quote.

## If I have this backwards

If the server *does* return a `month` object that `types.go` simply does not model, then the right fix is the opposite one: add it to `types.go` so `quota` can print it and the typed client can see it, and keep these checks as they were. I can't see the live API from here to tell which it is. Happy to send that version instead — say the word and I'll close this.

Docs-only; no code changes.
