### PR TITLE
fix: make upload failures safe and quota checks accurate

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"filippo.io/age"
@@ -1164,6 +1165,27 @@ func TestControlCharactersInHeaderValuesAreUsageErrors(t *testing.T) {
 				t.Fatalf("bad input reported as a network fault: %q", r.stderr)
 			}
 		})
+	}
+	if f.count() != 0 {
+		t.Fatalf("no request should have been sent, got %d", f.count())
+	}
+}
+
+func TestHeaderValidationPrecedesReadingStdin(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+
+	cases := [][]string{
+		{"upload", "-", "--name", "a\nb.txt"},
+		{"upload", "-", "--content-type", "text/x\ny"},
+	}
+	for _, args := range cases {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, iotest.ErrReader(errors.New("stdin must not be read")), &stdout, &stderr, "1.2.3")
+		if code != ExitUsage {
+			t.Errorf("%q: exit = %d, want %d; stderr = %q", args, code, ExitUsage, stderr.String())
+		}
 	}
 	if f.count() != 0 {
 		t.Fatalf("no request should have been sent, got %d", f.count())

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -95,44 +95,45 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 			return usagef("--link-expires: %v", err)
 		}
 	}
-
 	c, err := a.client()
 	if err != nil {
 		return err
 	}
 
-	src, size, name, cleanup, err := a.openSource(path, f.name)
+	originalName := resolvedUploadName(path, f.name)
+	name := originalName
+	ct := f.contentType
+	if ct == "" {
+		ct = contentTypeFor(name)
+	}
+	if f.encrypt {
+		if !strings.HasSuffix(strings.ToLower(name), ".age") {
+			name += ".age"
+		}
+		ct = encryptedContentType
+	}
+	if err := validateHeaderValue("file name", name); err != nil {
+		return err
+	}
+	if err := validateHeaderValue("--content-type", ct); err != nil {
+		return err
+	}
+
+	src, size, _, cleanup, err := a.openSource(path, f.name)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 
-	ct := f.contentType
-	if ct == "" {
-		ct = contentTypeFor(name)
-	}
 	var encrypted *encryptedUpload
 	if f.encrypt {
-		encrypted, err = encryptForUpload(src, name, f.recipient, f.identityOut)
+		encrypted, err = encryptForUpload(src, originalName, f.recipient, f.identityOut)
 		if err != nil {
 			return err
 		}
 		defer encrypted.cleanup()
 		src = encrypted.Reader
 		size = encrypted.Size
-		if !strings.HasSuffix(strings.ToLower(name), ".age") {
-			name += ".age"
-		}
-		ct = encryptedContentType
-	}
-	// Both values are sent as HTTP headers, so reject anything the transport
-	// would refuse. name may come from --name or from the file's basename, which
-	// on POSIX can legitimately contain a newline.
-	if err := validateHeaderValue("file name", name); err != nil {
-		return err
-	}
-	if err := validateHeaderValue("--content-type", ct); err != nil {
-		return err
 	}
 
 	opts := api.UploadOptions{Name: name, Size: size, ExpiresIn: expiresIn, ContentType: ct}
@@ -216,21 +217,31 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 // leaving it behind makes the obvious retry of the same command fail with
 // "identity file already exists" — a usage error for arguments that were right.
 //
-// A request that failed without a response is different: the file may have been
-// stored anyway, in which case the identity is the only way to ever read it.
-// Those are kept, and the caller is told why.
+// A transport or server failure is different: the file may have been stored
+// even though no success response reached the client. Those identities are
+// kept, and the caller is told why.
 func (a *app) discardUnusedIdentity(e *encryptedUpload, err error) {
 	if e.IdentityFile == "" {
 		return
 	}
 	var ae *api.Error
-	if errors.As(err, &ae) && ae.Status >= 400 {
+	if errors.As(err, &ae) && ae.Status >= 400 && ae.Status < 500 {
 		// The server rejected the request, so no ciphertext exists.
 		if os.Remove(e.IdentityFile) == nil {
 			return
 		}
 	}
 	fmt.Fprintf(a.stderr, "warning: kept identity file %s; the upload may still have stored the file, so check `aispace ls` before removing it\n", e.IdentityFile)
+}
+
+func resolvedUploadName(path, nameFlag string) string {
+	if nameFlag != "" {
+		return nameFlag
+	}
+	if path == "-" {
+		return "stdin"
+	}
+	return filepath.Base(path)
 }
 
 // openSource returns a seekable reader for path (or stdin buffered to a temp
@@ -252,10 +263,7 @@ func (a *app) openSource(path, nameFlag string) (io.ReadSeeker, int64, string, f
 			cleanup()
 			return nil, 0, "", noop, &codedError{code: "io", err: err, exit: ExitGeneric}
 		}
-		name := nameFlag
-		if name == "" {
-			name = "stdin"
-		}
+		name := resolvedUploadName(path, nameFlag)
 		return tmp, n, name, cleanup, nil
 	}
 	fh, err := os.Open(path)
@@ -277,16 +285,10 @@ func (a *app) openSource(path, nameFlag string) (io.ReadSeeker, int64, string, f
 		saved := a.stdin
 		a.stdin = fh
 		defer func() { a.stdin = saved }()
-		name := nameFlag
-		if name == "" {
-			name = filepath.Base(path)
-		}
+		name := resolvedUploadName(path, nameFlag)
 		return a.openSource("-", name)
 	}
-	name := nameFlag
-	if name == "" {
-		name = filepath.Base(path)
-	}
+	name := resolvedUploadName(path, nameFlag)
 	return fh, st.Size(), name, func() { fh.Close() }, nil
 }
 

--- a/cmd/upload_identity_test.go
+++ b/cmd/upload_identity_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -9,6 +10,29 @@ import (
 
 	"github.com/aispace-sh/aispace-client/internal/config"
 )
+
+func TestInvalidEncryptedUploadLeavesNoIdentity(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+	dir := t.TempDir()
+	src := filepath.Join(dir, "secret.pdf")
+	if err := os.WriteFile(src, []byte("confidential"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	identity := filepath.Join(dir, "secret.agekey")
+
+	r := run("", "upload", src, "--name", "bad\nname.pdf", "--encrypt", "--identity-out", identity)
+	if r.code != ExitUsage {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitUsage, r)
+	}
+	if _, err := os.Stat(identity); !os.IsNotExist(err) {
+		t.Fatalf("identity created before header validation: err=%v", err)
+	}
+	if f.count() != 0 {
+		t.Fatalf("no request should have been sent, got %d", f.count())
+	}
+}
 
 // A rejected upload used to leave the generated identity file on disk. Nothing
 // was stored, so it decrypted nothing, and it made the obvious retry of the
@@ -74,6 +98,39 @@ func TestUploadKeepsIdentityWhenOutcomeIsUnknown(t *testing.T) {
 	}
 	if !strings.Contains(r.stderr, "kept identity file") {
 		t.Fatalf("stderr should explain why the file was kept: %q", r.stderr)
+	}
+}
+
+func TestUploadKeepsIdentityAfterServerFailure(t *testing.T) {
+	for _, status := range []int{http.StatusInternalServerError, http.StatusBadGateway, http.StatusGatewayTimeout} {
+		t.Run(fmt.Sprintf("HTTP %d", status), func(t *testing.T) {
+			isolate(t)
+			f := newFakeServer(t)
+			writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+			dir := t.TempDir()
+			src := filepath.Join(dir, "secret.pdf")
+			if err := os.WriteFile(src, []byte("confidential"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			identity := filepath.Join(dir, "secret.agekey")
+
+			f.fail = func(r *http.Request) (int, string) {
+				if r.Method == http.MethodPost {
+					return status, `{"error":{"code":"internal","message":"server failed"}}`
+				}
+				return 0, ""
+			}
+			r := run("", "upload", src, "--encrypt", "--identity-out", identity)
+			if r.code != ExitGeneric {
+				t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+			}
+			if _, err := os.Stat(identity); err != nil {
+				t.Fatalf("identity removed after uncertain server failure: %v", err)
+			}
+			if !strings.Contains(r.stderr, "kept identity file") {
+				t.Fatalf("stderr should explain why the file was kept: %q", r.stderr)
+			}
+		})
 	}
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -214,8 +214,9 @@ encryption block) is still printed before the error, so the stored file is not l
 If the server *rejects* the upload (quota, size, rate limit, bad key), a file written by
 `--identity-out` is removed again: nothing was stored, so that identity decrypts nothing, and
 leaving it behind would make retrying the same command fail with `identity file already exists`.
-When the request fails without a response the outcome is unknown, so the identity is kept and a
-warning names it — check `aispace ls` before deleting it, because the file may have been stored.
+When the request fails without a response or returns a 5xx server error, the outcome is uncertain,
+so the identity is kept and a warning names it — check `aispace ls` before deleting it, because the
+file may have been stored.
 
 ### `aispace download`
 

--- a/docs/LLM_USAGE.md
+++ b/docs/LLM_USAGE.md
@@ -247,11 +247,11 @@ Rules of thumb:
   Pro block), so do not hand the same link to a system that polls it. One deliberate download per
   recipient is the intent.
 
-## Checking quota and monthly caps before a big upload or batch
+## Checking upload capacity before a big upload or batch
 
-There are two independent ways to be refused: **bytes** (`402`, storage) and **counts**
-(`429 monthly_upload_cap`, the plan's uploads for the calendar month). One `GET` covers both and
-avoids a wasted transfer:
+Uploads can be refused for **bytes** (`402`, storage), short-window rate limits (`429`), or the
+account-wide monthly count (`429 monthly_upload_cap`). A `quota` GET can pre-check storage and the
+short-window limits, but the monthly cap is reported only when an upload reaches it:
 
 ```sh
 need=2097152    # 2 MB
@@ -263,13 +263,14 @@ aispace quota --json | jq -e --argjson n "$need" '
   and .rate.uploads_day_remaining > 0' >/dev/null || { echo "cannot upload $need bytes now"; aispace quota; exit 4; }
 ```
 
-Before a **batch** of N uploads, check the daily upload count and the total bytes in one go:
+Before a **batch** of N uploads, check both short-window upload counts and the total bytes in one go:
 
 ```sh
 n=250; total=52428800   # 250 files, 50 MB together
 aispace quota --json | jq -e --argjson n "$n" --argjson t "$total" '
   .key.remaining_bytes >= $t
   and .account.remaining_bytes >= $t
+  and .rate.uploads_hour_remaining >= $n
   and .rate.uploads_day_remaining >= $n' >/dev/null || {
     echo "batch of $n would exceed a cap; see aispace quota"; exit 4; }
 ```


### PR DESCRIPTION
## Summary

- validate resolved upload headers before reading stdin or creating encrypted output and identity files
- remove generated identities only after definitive 4xx upload rejections, while retaining them after transport and 5xx failures
- correct the quota guide so monthly caps are not described as pre-checkable and batch guards include the hourly allowance

## Regression coverage

- invalid names and content types do not consume stdin
- invalid encrypted uploads do not create identity files
- HTTP 500, 502, and 504 responses retain the only decryption identity
- existing 4xx cleanup, transport-failure, and link-failure behavior remains covered

## Verification

- go test -race ./...
- go vet ./...
- npm test
- gofmt check
- shell syntax checks for install.sh and examples