### PR TITLE
feat(download): --verify checks downloaded bytes against the recorded SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ aispace upload notes.md --shared --json
 # Receive, manage, and revoke.
 aispace ls --json
 aispace download <file_id> --output ./file
+aispace download <file_id> --output ./file --verify   # check the recorded SHA-256
 aispace link <file_id> --expires 30m --max-downloads 1
 aispace revoke <link_id>
 aispace rm <file_id>

--- a/cmd/download_verify_test.go
+++ b/cmd/download_verify_test.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// verifyServer serves one file plus its metadata, so a test can decide whether
+// the recorded digest matches the bytes actually served.
+type verifyServer struct {
+	mu          sync.Mutex
+	srv         *httptest.Server
+	key         string
+	content     []byte
+	recorded    string // the sha256 the metadata reports
+	metaHits    int
+	contentHits int
+}
+
+func newVerifyServer(t *testing.T, content string, recorded string) *verifyServer {
+	t.Helper()
+	v := &verifyServer{key: "ask_validkey0000000000000000000000", content: []byte(content), recorded: recorded}
+	v.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+v.key {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_key","message":"Invalid key"}}`))
+			return
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/content"):
+			v.mu.Lock()
+			v.contentHits++
+			v.mu.Unlock()
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(v.content)
+		case strings.HasPrefix(r.URL.Path, "/v1/files/"):
+			v.mu.Lock()
+			v.metaHits++
+			v.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			meta := map[string]any{
+				"id": "01A", "name": "a.bin", "content_type": "application/octet-stream",
+				"size_bytes": len(v.content), "visibility": "account",
+				"created_at": 1757000000, "expires_at": 1757604800,
+			}
+			if v.recorded != "" {
+				meta["sha256"] = v.recorded
+			}
+			_ = json.NewEncoder(w).Encode(meta)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(v.srv.Close)
+	return v
+}
+
+func (v *verifyServer) counts() (int, int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.metaHits, v.contentHits
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestDownloadVerifyAcceptsMatchingDigest(t *testing.T) {
+	isolate(t)
+	const body = "the real contents"
+	v := newVerifyServer(t, body, sha256Hex(body))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	r := run("", "download", "01A", "--output", out, "--verify")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	if !strings.Contains(r.stdout, "sha256 verified") {
+		t.Errorf("stdout should report the check: %q", r.stdout)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil || string(got) != body {
+		t.Fatalf("content = %q err=%v", got, err)
+	}
+	if meta, content := v.counts(); meta != 1 || content != 1 {
+		t.Errorf("requests: metadata=%d content=%d, want 1 and 1", meta, content)
+	}
+}
+
+// A digest that does not match must leave nothing behind: a caller that ignores
+// the exit code would otherwise read a corrupt file as if it were good.
+func TestDownloadVerifyRemovesCorruptOutput(t *testing.T) {
+	isolate(t)
+	v := newVerifyServer(t, "tampered contents", sha256Hex("the real contents"))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	r := run("", "download", "01A", "--output", out, "--verify")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if !strings.Contains(r.stderr, "checksum mismatch") {
+		t.Errorf("stderr = %q", r.stderr)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("corrupt output was left on disk: err=%v", err)
+	}
+}
+
+// Without a recorded digest there is nothing to compare against; say so instead
+// of reporting success for a check that never happened.
+func TestDownloadVerifyRefusesWhenNoDigestRecorded(t *testing.T) {
+	isolate(t)
+	v := newVerifyServer(t, "contents", "")
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	r := run("", "download", "01A", "--output", out, "--verify")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if !strings.Contains(r.stderr, "no recorded SHA-256") {
+		t.Errorf("stderr = %q", r.stderr)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Errorf("nothing should have been written")
+	}
+	// The body is not worth transferring when it can never be checked.
+	if _, content := v.counts(); content != 0 {
+		t.Errorf("content was downloaded anyway (%d requests)", content)
+	}
+}
+
+// The default path must be untouched: same bytes, and no extra metadata call.
+func TestDownloadWithoutVerifyMakesNoExtraRequest(t *testing.T) {
+	isolate(t)
+	const body = "the real contents"
+	v := newVerifyServer(t, body, sha256Hex(body))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	r := run("", "download", "01A", "--output", out)
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got, _ := os.ReadFile(out)
+	if string(got) != body {
+		t.Fatalf("content = %q", got)
+	}
+	if meta, content := v.counts(); meta != 0 || content != 1 {
+		t.Errorf("requests: metadata=%d content=%d, want 0 and 1", meta, content)
+	}
+}
+
+func TestDownloadVerifyJSONReportsDigest(t *testing.T) {
+	isolate(t)
+	const body = "the real contents"
+	v := newVerifyServer(t, body, sha256Hex(body))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	r := run("", "download", "01A", "--output", out, "--verify", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(r.stdout), &got); err != nil {
+		t.Fatalf("stdout %q: %v", r.stdout, err)
+	}
+	if got["sha256"] != sha256Hex(body) || got["output"] != out || got["file_id"] != "01A" {
+		t.Fatalf("json = %v", got)
+	}
+}
+
+// stdout cannot be recalled, so the exit code carries the result and the
+// message must not pretend the bytes were withheld.
+func TestDownloadVerifyToStdoutStillReportsMismatch(t *testing.T) {
+	isolate(t)
+	v := newVerifyServer(t, "tampered", sha256Hex("real"))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+
+	r := run("", "download", "01A", "--output", "-", "--verify")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if r.stdout != "tampered" {
+		t.Errorf("stdout = %q, want the streamed bytes", r.stdout)
+	}
+	if !strings.Contains(r.stderr, "already written to stdout") {
+		t.Errorf("stderr should say the bytes escaped: %q", r.stderr)
+	}
+}
+
+// Digests are hex; comparison must not depend on the server's casing.
+func TestDownloadVerifyIsCaseInsensitive(t *testing.T) {
+	isolate(t)
+	const body = "the real contents"
+	v := newVerifyServer(t, body, strings.ToUpper(sha256Hex(body)))
+	writeConfig(t, config.File{Key: v.key, URL: v.srv.URL})
+	out := filepath.Join(t.TempDir(), "a.bin")
+
+	if r := run("", "download", "01A", "--output", out, "--verify"); r.code != ExitOK {
+		t.Fatalf("uppercase digest rejected: %+v", r)
+	}
+}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,10 +19,18 @@ import (
 
 func (a *app) downloadCmd() *cobra.Command {
 	var output string
+	var verify bool
 	cmd := &cobra.Command{
-		Use:   "download <file_id> --output <path|->",
+		Use:   "download <file_id> --output <path|-> [--verify]",
 		Short: "Download an accessible file by ID without creating a public link",
-		Args:  exactArgs(1, "<file_id>"),
+		Long: "Downloads a file this key owns or that is shared with the account, using key\n" +
+			"authentication rather than a public link.\n\n" +
+			"With --verify the bytes are hashed as they are written and compared with the\n" +
+			"SHA-256 the API recorded for the file. That costs one extra metadata request, and\n" +
+			"only works for files uploaded with --sha256, because otherwise there is no\n" +
+			"recorded digest to compare against.",
+		Example: "  aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf --verify",
+		Args:    exactArgs(1, "<file_id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if output == "" {
 				return usagef("--output is required")
@@ -30,15 +42,50 @@ func (a *app) downloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := c.Download(cmd.Context(), args[0])
+			id := args[0]
+
+			// Read the recorded digest before transferring anything: without one
+			// there is nothing to compare against, and saying so now avoids
+			// downloading a body that could never be checked.
+			var want string
+			if verify {
+				res, err := c.GetFile(cmd.Context(), id)
+				if err != nil {
+					return err
+				}
+				if want = res.Value.SHA256; want == "" {
+					return &codedError{
+						code: "no_checksum",
+						err:  fmt.Errorf("file %s has no recorded SHA-256 to verify against; it was uploaded without --sha256", id),
+						exit: ExitGeneric,
+					}
+				}
+			}
+
+			resp, err := c.Download(cmd.Context(), id)
 			if err != nil {
 				return err
 			}
 			defer resp.Body.Close()
-			if output == "-" {
-				_, err = io.Copy(a.stdout, resp.Body)
-				return err
+
+			sum := sha256.New()
+			body := io.Reader(resp.Body)
+			if verify {
+				body = io.TeeReader(resp.Body, sum)
 			}
+
+			if output == "-" {
+				if _, err := io.Copy(a.stdout, body); err != nil {
+					return &codedError{code: "io", err: err, exit: ExitGeneric}
+				}
+				if !verify {
+					return nil
+				}
+				// stdout cannot be taken back, so the exit code is the only
+				// signal left; say so rather than implying the bytes were held.
+				return checkDigest(want, sum, "the bytes were already written to stdout")
+			}
+
 			out, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 			if err != nil {
 				if errors.Is(err, os.ErrExist) {
@@ -53,22 +100,52 @@ func (a *app) downloadCmd() *cobra.Command {
 					_ = os.Remove(output)
 				}
 			}()
-			if _, err = io.Copy(out, resp.Body); err != nil {
+			if _, err = io.Copy(out, body); err != nil {
 				return &codedError{code: "io", err: err, exit: ExitGeneric}
 			}
 			if err = out.Close(); err != nil {
 				return &codedError{code: "io", err: err, exit: ExitGeneric}
 			}
+			if verify {
+				// ok is still false here, so the deferred cleanup removes a
+				// corrupt file rather than leaving it where it may be trusted.
+				if err := checkDigest(want, sum, ""); err != nil {
+					return err
+				}
+			}
 			ok = true
 			if a.jsonOut {
-				return a.printJSONValue(map[string]string{"file_id": args[0], "output": output})
+				payload := map[string]string{"file_id": id, "output": output}
+				if verify {
+					payload["sha256"] = hex.EncodeToString(sum.Sum(nil))
+				}
+				return a.printJSONValue(payload)
 			}
-			fmt.Fprintf(a.stdout, "downloaded %s -> %s\n", args[0], output)
+			if verify {
+				fmt.Fprintf(a.stdout, "downloaded %s -> %s sha256 verified\n", id, output)
+				return nil
+			}
+			fmt.Fprintf(a.stdout, "downloaded %s -> %s\n", id, output)
 			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "", "destination path, or - for stdout (required)")
+	cmd.Flags().BoolVar(&verify, "verify", false, "check the downloaded bytes against the file's recorded SHA-256 (one extra API call)")
 	return cmd
+}
+
+// checkDigest compares a streamed hash with the digest the API recorded for the
+// file. note describes anything the caller could no longer take back.
+func checkDigest(want string, h hash.Hash, note string) error {
+	got := hex.EncodeToString(h.Sum(nil))
+	if strings.EqualFold(got, want) {
+		return nil
+	}
+	msg := fmt.Sprintf("checksum mismatch: recorded %s, downloaded %s", want, got)
+	if note != "" {
+		msg += " (" + note + ")"
+	}
+	return &codedError{code: "checksum_mismatch", err: errors.New(msg), exit: ExitGeneric}
 }
 
 func (a *app) linkCmd() *cobra.Command {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -221,7 +221,7 @@ file may have been stored.
 ### `aispace download`
 
 ```
-aispace download <file_id> --output <path|-> [--json]
+aispace download <file_id> --output <path|-> [--verify] [--json]
 ```
 
 Downloads a file owned by the current key or shared with the account by another key. This uses
@@ -231,6 +231,26 @@ it cannot be combined with `--json`.
 
 ```sh
 aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf
+aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf --verify
+```
+
+`--verify` hashes the bytes as they are written and compares the result with the SHA-256 the API
+recorded for the file, so a truncated or altered transfer is caught rather than trusted. It reads
+the file's metadata first, which costs **one extra request** against the per-minute rate limit, and
+only works for files uploaded with `--sha256` — without a recorded digest there is nothing to
+compare against and the command exits 1 with `no_checksum` rather than reporting a check it did
+not perform.
+
+On a mismatch the exit code is 1 with `checksum_mismatch`, and the output file is removed, so a
+caller that ignores the exit code cannot pick up a corrupt file. With `--output -` the bytes have
+already gone to stdout by the time the digest is known; the mismatch is still reported and the
+exit code is still 1, but the caller has to discard what it read.
+
+```sh
+aispace download "$id" --output report.pdf --verify || echo "corrupt, nothing written"
+
+# --json adds the digest that was verified
+aispace download "$id" --output report.pdf --verify --json | jq -r .sha256
 ```
 
 ### `aispace keygen`

--- a/skills/aispace/SKILL.md
+++ b/skills/aispace/SKILL.md
@@ -111,6 +111,10 @@ and the durable destination has been verified.
 
 - List this key's files and account-shared files: `aispace ls --json`
 - Download an accessible file without a public link: `aispace download FILE_ID --output PATH`
+- Add `--verify` when the artifact will be acted on rather than just inspected. It checks the
+  bytes against the SHA-256 recorded at upload and deletes the output on a mismatch, so a
+  truncated transfer cannot be mistaken for a complete one. It needs the file to have been
+  uploaded with `--sha256`, and costs one extra request.
 - Inspect one file, including `enc_alg`: `aispace info FILE_ID --json`
 
 Only the key that uploaded a file may manage it or its public links. Account-shared sibling keys


### PR DESCRIPTION
## The gap

The client already takes integrity seriously in two of three directions:

- `upload --sha256` sends `X-SHA256` so the server can verify what it stored.
- `install.sh` and the npm installer both verify every binary against `checksums.txt`.
- `decrypt` gets authentication for free, because age is an AEAD.

`download` has nothing. A truncated or altered transfer produces a file that looks complete — exit 0, bytes on disk — and the caller has no way to tell whether they are the bytes that were uploaded. That is the one direction where the recorded digest is already sitting in the API response (`File.sha256`, which `aispace info` prints) and simply was not used.

## What this adds

```sh
aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf --verify
# downloaded 01J8ZQ3V9N7X2K4M6P8R0T2W4Y -> report.pdf sha256 verified
```

The bytes are hashed with `io.TeeReader` **while** they are written, so there is no second pass over the file and no extra memory for large transfers.

Three design points that matter more than the hashing itself:

**The digest is read before the transfer starts.** A file uploaded without `--sha256` has no recorded digest, so there is nothing to compare against. Rather than silently reporting success for a check that never ran, the command exits 1 with `no_checksum` — and it does so *before* downloading a body it could never have verified:

```
error: file 01A has no recorded SHA-256 to verify against; it was uploaded without --sha256 (no_checksum)
```

**A mismatch removes the output file.** The `ok` guard already deletes a partial download, so verification just runs before `ok` is set. This is the part that makes the feature worth having: a caller that ignores the exit code still cannot pick up a corrupt file, which is the failure mode the feature exists to prevent.

```
error: checksum mismatch: recorded 8ff1…, downloaded 4c2a… (checksum_mismatch)
```

**`--output -` is honest about what it cannot undo.** The bytes have already gone to stdout by the time the digest is known. The mismatch is still reported and the exit still 1, but the message says so rather than implying the data was withheld:

```
error: checksum mismatch: recorded … , downloaded … (the bytes were already written to stdout) (checksum_mismatch)
```

Comparison is case-insensitive, since hex digests are presented either way and casing is not a mismatch. `--json` gains the digest that was checked:

```sh
aispace download "$id" --output report.pdf --verify --json | jq -r .sha256
```

## Off by default, deliberately

`--verify` reads the file's metadata first, which is **one extra request** against `requests_per_minute`. That is not a cost to impose on an agent doing bulk transfers without it asking, so the default path is byte-for-byte unchanged — there is a test asserting the metadata endpoint is not touched without the flag.

If you would rather have integrity on by default and an opt-out, that is a one-line change and I am happy to send it instead.

## Tests

Seven, in their own file so nothing collides with `cmd_test.go`, driven by a small server that lets the test decide whether the recorded digest matches the bytes served:

| Test | Asserts |
|---|---|
| `…AcceptsMatchingDigest` | success path, and exactly 1 metadata + 1 content request |
| `…RemovesCorruptOutput` | mismatch exits 1 **and leaves nothing on disk** |
| `…RefusesWhenNoDigestRecorded` | clear error, and the body is never transferred |
| `TestDownloadWithoutVerifyMakesNoExtraRequest` | default path unchanged, 0 metadata requests |
| `…JSONReportsDigest` | `--json` carries the verified digest |
| `…ToStdoutStillReportsMismatch` | bytes stream, exit 1, message admits they escaped |
| `…IsCaseInsensitive` | an uppercase recorded digest is not a mismatch |

`gofmt`, `go vet ./...` and `go test ./...` clean. Docs updated in `docs/CLI.md`, the README quickstart, and `skills/aispace/SKILL.md` — the skill entry tells an agent to reach for `--verify` when it is going to *act* on an artifact rather than just look at it.
