### PR TITLE
feat(rm,revoke): --continue finishes a batch past per-ID failures

### DIFF
--- a/cmd/batch_test.go
+++ b/cmd/batch_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// batchServer deletes anything except IDs containing "missing", which 404, and
+// fails everything with 401 once unauthorized is set.
+type batchServer struct {
+	mu           sync.Mutex
+	srv          *httptest.Server
+	key          string
+	unauthorized bool
+	seen         []string
+}
+
+func newBatchServer(t *testing.T) *batchServer {
+	t.Helper()
+	b := &batchServer{key: "ask_validkey0000000000000000000000"}
+	b.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Path[strings.LastIndexByte(r.URL.Path, '/')+1:]
+		b.mu.Lock()
+		b.seen = append(b.seen, id)
+		unauth := b.unauthorized
+		b.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if unauth {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_key","message":"Invalid key"}}`))
+			return
+		}
+		if strings.Contains(id, "missing") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"No such id"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *batchServer) attempted() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.seen...)
+}
+
+// Without --continue the first failure must still stop the run, so existing
+// callers keep the behaviour they were written against.
+func TestRmStopsAtFirstFailureByDefault(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "rm", "keep1", "missing2", "keep3")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if got := b.attempted(); len(got) != 2 || got[1] != "missing2" {
+		t.Fatalf("attempted %v, want to stop after missing2", got)
+	}
+	if !strings.Contains(r.stdout, "deleted keep1") || strings.Contains(r.stdout, "keep3") {
+		t.Fatalf("stdout = %q", r.stdout)
+	}
+}
+
+// --continue attempts every ID and still fails overall.
+func TestRmContinuePastMissingIDs(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "rm", "--continue", "keep1", "missing2", "keep3")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if got := b.attempted(); len(got) != 3 {
+		t.Fatalf("attempted %v, want all three", got)
+	}
+	for _, want := range []string{"deleted keep1", "deleted keep3"} {
+		if !strings.Contains(r.stdout, want) {
+			t.Errorf("stdout missing %q: %q", want, r.stdout)
+		}
+	}
+	if !strings.Contains(r.stderr, "missing2") || !strings.Contains(r.stderr, "not_found") {
+		t.Errorf("stderr should name the failed ID: %q", r.stderr)
+	}
+	// The failure is reported once, not again by the top-level handler.
+	if n := strings.Count(r.stderr, "not_found"); n != 1 {
+		t.Errorf("failure reported %d times, want 1: %q", n, r.stderr)
+	}
+}
+
+// A rejected key applies to every remaining ID, so --continue must not keep
+// hammering the API with requests that cannot succeed.
+func TestRmContinueStopsOnUnauthorized(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	b.unauthorized = true
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "rm", "--continue", "a", "b", "c", "d")
+	if r.code != ExitAuth {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitAuth, r)
+	}
+	if got := b.attempted(); len(got) != 1 {
+		t.Fatalf("attempted %v, want to give up after the first 401", got)
+	}
+}
+
+func TestRevokeContinuePastMissingIDs(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "revoke", "--continue", "link1", "missinglink", "link3")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if got := b.attempted(); len(got) != 3 {
+		t.Fatalf("attempted %v, want all three", got)
+	}
+	if !strings.Contains(r.stdout, "revoked link1") || !strings.Contains(r.stdout, "revoked link3") {
+		t.Errorf("stdout = %q", r.stdout)
+	}
+}
+
+// Successes stay machine-readable on stdout while the failure goes to stderr as
+// a JSON error object, so a caller parsing stdout is not handed a mixed stream.
+func TestRmContinueJSONKeepsStreamsSeparate(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "rm", "--continue", "--json", "keep1", "missing2", "keep3")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d: %+v", r.code, r)
+	}
+	wantOut := `{"deleted":"keep1"}` + "\n" + `{"deleted":"keep3"}` + "\n"
+	if r.stdout != wantOut {
+		t.Fatalf("stdout = %q, want %q", r.stdout, wantOut)
+	}
+	if !strings.Contains(r.stderr, `"code":"not_found"`) || !strings.Contains(r.stderr, `"exit_code":1`) {
+		t.Fatalf("stderr = %q", r.stderr)
+	}
+	if n := strings.Count(r.stderr, `"error"`); n != 1 {
+		t.Fatalf("error reported %d times, want 1: %q", n, r.stderr)
+	}
+}
+
+// Every ID succeeding must still exit 0.
+func TestRmContinueAllSucceed(t *testing.T) {
+	isolate(t)
+	b := newBatchServer(t)
+	writeConfig(t, config.File{Key: b.key, URL: b.srv.URL})
+
+	r := run("", "rm", "--continue", "a", "b")
+	if r.code != ExitOK || r.stderr != "" {
+		t.Fatalf("%+v", r)
+	}
+}

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -234,59 +235,98 @@ func (a *app) linksCmd() *cobra.Command {
 }
 
 func (a *app) rmCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "rm <file_id>...",
+	var keepGoing bool
+	cmd := &cobra.Command{
+		Use:   "rm <file_id>... [--continue]",
 		Short: "Delete one or more files (revokes all their links)",
-		Long:  "Deletes files in order and stops at the first failure. With --json prints one {\"deleted\": id} object per line.",
-		Args:  minArgs(1, "<file_id>..."),
+		Long: "Deletes files in order. By default it stops at the first failure, so the IDs after\n" +
+			"it are left alone. With --continue every ID is attempted and the command still\n" +
+			"exits non-zero if any of them failed, which suits cleaning up a list that may\n" +
+			"contain IDs already deleted or expired.\n\n" +
+			"With --json it prints one {" + `"deleted"` + ": id} object per line.",
+		Args: minArgs(1, "<file_id>..."),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := a.client()
 			if err != nil {
 				return err
 			}
-			for _, id := range args {
-				if err := c.DeleteFile(cmd.Context(), id); err != nil {
-					return prefixID(id, len(args) > 1, err)
-				}
-				if a.jsonOut {
-					if err := a.printJSONValue(map[string]any{"deleted": id}); err != nil {
-						return err
-					}
-					continue
-				}
-				fmt.Fprintf(a.stdout, "deleted %s\n", id)
-			}
-			return nil
+			return a.runBatch(args, keepGoing, "deleted", func(id string) error {
+				return c.DeleteFile(cmd.Context(), id)
+			})
 		},
 	}
+	cmd.Flags().BoolVar(&keepGoing, "continue", false, "attempt every ID instead of stopping at the first failure")
+	return cmd
 }
 
 func (a *app) revokeCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "revoke <link_id>...",
+	var keepGoing bool
+	cmd := &cobra.Command{
+		Use:   "revoke <link_id>... [--continue]",
 		Short: "Revoke one or more share links",
-		Long:  "Revokes links in order and stops at the first failure. With --json prints one {\"revoked\": id} object per line.",
-		Args:  minArgs(1, "<link_id>..."),
+		Long: "Revokes links in order. By default it stops at the first failure; with --continue\n" +
+			"every ID is attempted and the command still exits non-zero if any of them failed.\n\n" +
+			"With --json it prints one {" + `"revoked"` + ": id} object per line.",
+		Args: minArgs(1, "<link_id>..."),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := a.client()
 			if err != nil {
 				return err
 			}
-			for _, id := range args {
-				if err := c.RevokeLink(cmd.Context(), id); err != nil {
-					return prefixID(id, len(args) > 1, err)
-				}
-				if a.jsonOut {
-					if err := a.printJSONValue(map[string]any{"revoked": id}); err != nil {
-						return err
-					}
-					continue
-				}
-				fmt.Fprintf(a.stdout, "revoked %s\n", id)
-			}
-			return nil
+			return a.runBatch(args, keepGoing, "revoked", func(id string) error {
+				return c.RevokeLink(cmd.Context(), id)
+			})
 		},
 	}
+	cmd.Flags().BoolVar(&keepGoing, "continue", false, "attempt every ID instead of stopping at the first failure")
+	return cmd
+}
+
+// runBatch applies op to each ID, reporting one line per success. Without
+// keepGoing it returns at the first failure, leaving the remaining IDs
+// untouched. With keepGoing it reports each failure as it happens and returns
+// the first one at the end, so the exit code still reflects that something
+// failed.
+func (a *app) runBatch(ids []string, keepGoing bool, verb string, op func(string) error) error {
+	multi := len(ids) > 1
+	var first error
+	for _, id := range ids {
+		if err := op(id); err != nil {
+			err = prefixID(id, multi, err)
+			if !keepGoing || batchIsHopeless(err) {
+				// Report what has already been attempted before giving up.
+				if first != nil {
+					return first
+				}
+				return err
+			}
+			_, code := a.classify(err)
+			a.printError(err, code)
+			if first == nil {
+				first = &reportedError{err: err}
+			}
+			continue
+		}
+		if a.jsonOut {
+			if err := a.printJSONValue(map[string]any{verb: id}); err != nil {
+				return err
+			}
+			continue
+		}
+		fmt.Fprintf(a.stdout, "%s %s\n", verb, id)
+	}
+	return first
+}
+
+// batchIsHopeless reports whether an error will affect every remaining ID, so
+// there is nothing to gain from trying them. A rejected key or an exhausted
+// rate limit applies to the whole batch; a missing ID does not.
+func batchIsHopeless(err error) bool {
+	var ae *api.Error
+	if errors.As(err, &ae) {
+		return ae.Status == http.StatusUnauthorized || ae.Status == http.StatusTooManyRequests
+	}
+	return false
 }
 
 func (a *app) quotaCmd() *cobra.Command {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,14 @@ func usagef(format string, args ...any) error {
 	return &usageError{msg: fmt.Sprintf(format, args...)}
 }
 
+// reportedError wraps an error that has already been written to stderr, so Run
+// does not print it a second time. It keeps the wrapped error reachable through
+// errors.As, so the exit code is still derived from the original.
+type reportedError struct{ err error }
+
+func (e *reportedError) Error() string { return e.err.Error() }
+func (e *reportedError) Unwrap() error { return e.err }
+
 // codedError is a local (non-API) error with a code for the `error: msg (code)` line.
 type codedError struct {
 	code string
@@ -84,7 +92,10 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer, version strin
 		return ExitOK
 	}
 	code, apiCode := a.classify(err)
-	a.printError(err, apiCode)
+	var reported *reportedError
+	if !errors.As(err, &reported) {
+		a.printError(err, apiCode)
+	}
 	return code
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -326,7 +326,7 @@ aispace ls --json | jq -r --argjson t "$(date +%s)" '.files[] | select(.expires_
 ### `aispace rm`
 
 ```
-aispace rm <file_id> [<file_id>...] [--json]
+aispace rm <file_id> [<file_id>...] [--continue] [--json]
 ```
 
 Deletes files (`DELETE /v1/files/:id`). All share links of the file stop working immediately and
@@ -343,17 +343,35 @@ not deleted; the ones already printed were. The exit code is the one for the und
 for `not_found`, 3 for a bad key), and when more than one ID was given the message is prefixed
 with the ID that failed.
 
+`--continue` attempts every ID instead. Failures are reported to stderr as they happen, successes
+still go to stdout, and the command exits non-zero if any ID failed — so a cleanup pass over a list
+that may contain already-deleted or expired IDs completes in one call:
+
+```sh
+aispace ls --json | jq -r '.files[].id' | xargs aispace rm --continue
+```
+
+A failure that applies to every remaining ID still stops the run: a rejected key (`401`) or an
+exhausted rate limit (`429`) would fail for all of them, so `--continue` gives up rather than
+spending the rest of the batch on requests that cannot succeed. A missing ID is not treated that
+way, because it says nothing about the others.
+
+With `--json` the two streams stay separate: stdout carries only `{"deleted": id}` lines, and each
+failure is a JSON error object on stderr, so a caller parsing stdout is never handed a mixed
+stream.
+
 ### `aispace revoke`
 
 ```
-aispace revoke <link_id> [<link_id>...] [--json]
+aispace revoke <link_id> [<link_id>...] [--continue] [--json]
 ```
 
 Revokes share links (`DELETE /v1/links/:id`). The file remains. Link IDs come from
 `upload --link --json`, `link --json`, or `aispace links <file_id>`.
 
 Like `rm`, it prints `revoked <id>` per link (or `{"revoked":"<id>"}` per line with `--json`),
-processes IDs in order and stops at the first failure.
+processes IDs in order, stops at the first failure, and accepts `--continue` to attempt every ID
+instead.
 
 ### `aispace links`
 

--- a/skills/aispace/SKILL.md
+++ b/skills/aispace/SKILL.md
@@ -120,6 +120,8 @@ can list, inspect, and download the file, but cannot perform these owner-only op
 - List link IDs and counters: `aispace links FILE_ID --json`
 - Revoke a link created by this key: `aispace revoke LINK_ID`
 - Delete a file uploaded by this key and invalidate all its links: `aispace rm FILE_ID`
+- When cleaning up several IDs at once, add `--continue` to `rm` or `revoke`. Without it the
+  first already-deleted or expired ID stops the pass and leaves the rest behind.
 
 Treat revoke and delete as state-changing actions. Do them only when requested or when they are an
 explicit step in the user's stated workflow. Remember that expiry or deletion cannot recall bytes


### PR DESCRIPTION
## The gap

`rm` and `revoke` return at the first failure. Cleanup is exactly where that hurts: an agent deleting the IDs it uploaded earlier hits one that already expired, and **everything after it is left behind** — still stored, still counting against the key's budget. The caller can't even tell how far the pass got without diffing `ls` afterwards.

```
$ aispace rm keep1 missing2 keep3
deleted keep1
error: missing2: No such id (not_found)     # exit 1 — keep3 was never attempted
```

That is reasonable as a default (you may well want to stop and look), but it leaves no way to say "this is a cleanup list, some of it is already gone, do what you can".

## What this adds

```sh
aispace ls --json | jq -r '.files[].id' | xargs aispace rm --continue
```

`--continue` attempts every ID, reports each failure to stderr as it happens, and still exits non-zero if any failed — so the pass completes in one call and the exit code still tells you something went wrong.

**Not every failure is worth continuing past.** A rejected key (`401`) or an exhausted rate limit (`429`) will fail for every remaining ID, so those still stop the run rather than spending the rest of the batch — and the rest of the rate limit — on requests that cannot succeed. A missing ID says nothing about the others, so it does not stop anything. There's a test asserting a `401` gives up after the *first* attempt rather than trying all four.

**Under `--json` the two streams stay separate.** stdout carries only the `{"deleted": id}` lines and failures are JSON error objects on stderr, so a caller parsing stdout is never handed a mixed stream:

```
stdout: {"deleted":"keep1"}
        {"deleted":"keep3"}
stderr: {"error":{"code":"not_found","exit_code":1,"message":"missing2: No such id","status":404}}
```

## Implementation notes

The two commands had the same loop, so rather than duplicating the new behaviour this factors it into `runBatch`. That's most of the diff in `cmd/files.go`.

One wrinkle worth flagging for review: failures printed *inside* the loop would otherwise be printed a second time by `Run` when the first error is returned at the end. Rather than special-casing, the returned error is wrapped in a small `reportedError` that `Run` recognises and skips printing. It implements `Unwrap`, so `classify` still reaches the underlying `api.Error` and the exit code is unaffected. Two tests assert the failure appears exactly once, in both text and JSON mode.

## Default is unchanged

`TestRmStopsAtFirstFailureByDefault` pins it: without the flag, the first failure still stops the run and the later IDs are never attempted. The existing `TestRmAndRevoke` and `TestRmRevokeMultiple` pass untouched.

Six new tests in their own file (`cmd/batch_test.go`), so nothing collides with `cmd_test.go`. `gofmt`, `go vet ./...`, `go test ./...` clean.

Independent of #10 — I merged both onto `main` locally and the combined tree builds and passes, so they can land in either order.

## Naming

I went with `--continue` as the most literal description. If you'd rather avoid the `curl --continue-at` connotation, `--keep-going` (make's `-k`) or `--force` are easy swaps — say which you prefer and I'll rename.
