### PR TITLE
feat(api): bound request phases instead of total duration, so slow links can move large files

### DIFF
--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"filippo.io/age"
 	"github.com/spf13/cobra"
+
+	"github.com/aispace-sh/aispace-client/internal/api"
 )
 
 const (
@@ -345,7 +346,7 @@ func (a *app) openEncryptedInput(ctx context.Context, input string) (io.Reader, 
 			return nil, func() {}, usagef("invalid URL: %v", err)
 		}
 		req.Header.Set("User-Agent", a.userAgent())
-		resp, err := (&http.Client{Timeout: 10 * time.Minute}).Do(req)
+		resp, err := api.NewHTTPClient().Do(req)
 		if err != nil {
 			return nil, func() {}, &codedError{code: "download", err: err, exit: ExitGeneric}
 		}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,6 +97,25 @@ idempotent `GET`s (`ls`, `quota`, and the metadata lookups). `monthly_upload_cap
 contacts@aispace.sh). Uploads, link creation and deletes are never
 retried automatically; the agent decides. `Retry-After` is echoed in the error message.
 
+## Timeouts
+
+There is **no deadline on a transfer as a whole**. A large file over a slow link is slow, not
+broken, and a single cap covering the response body would really be a bandwidth floor: at a
+ten-minute cap, a 100 MB upload has to sustain about 1.4 Mbit/s or fail after moving most of
+itself.
+
+What is bounded are the phases before any bytes flow, so an unreachable or silent server is still
+given up on quickly:
+
+| Phase | Limit |
+|---|---|
+| TCP connect | 30s |
+| TLS handshake | 10s |
+| Waiting for response headers | 60s |
+
+A stalled transfer is therefore ended by the peer or by the operator, not by a timer:
+`Ctrl-C`/`SIGTERM` cancels in-flight requests and exits `1` with code `interrupted`.
+
 ## Durations
 
 Flags that take a duration accept Go-style strings with an added `d` unit: `30s`, `15m`, `1h`,

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,12 +8,52 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// Per-phase timeouts for one request. There is deliberately no deadline on the
+// exchange as a whole: a large file over a slow link is slow, not broken.
+//
+// A single cap covering the body meant transfer time was really a bandwidth
+// floor. At the previous 10 minutes, a 100 MB upload — the documented maximum
+// on Pro — had to sustain roughly 1.4 Mbit/s or fail after transferring most of
+// itself. These bound the phases before any bytes flow instead, so an
+// unreachable or silent server is still given up on quickly.
+const (
+	// DialTimeout bounds establishing the TCP connection.
+	DialTimeout = 30 * time.Second
+	// TLSTimeout bounds the TLS handshake.
+	TLSTimeout = 10 * time.Second
+	// HeaderTimeout bounds the wait for response headers, which is what catches
+	// a server that accepts the connection and then goes quiet.
+	HeaderTimeout = 60 * time.Second
+)
+
+// NewHTTPClient returns the HTTP client used for aispace requests: quick to
+// give up before bytes start moving, patient once they are.
+func NewHTTPClient() *http.Client {
+	return newHTTPClient(DialTimeout, TLSTimeout, HeaderTimeout)
+}
+
+func newHTTPClient(dial, tlsHandshake, header time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: dial, KeepAlive: 30 * time.Second}).DialContext,
+			ForceAttemptHTTP2:     true,
+			TLSHandshakeTimeout:   tlsHandshake,
+			ResponseHeaderTimeout: header,
+			ExpectContinueTimeout: time.Second,
+			IdleConnTimeout:       90 * time.Second,
+			MaxIdleConnsPerHost:   2,
+		},
+	}
+}
 
 // MaxRetryAfter caps how long the client waits before retrying a 429.
 const MaxRetryAfter = 30 * time.Second
@@ -37,7 +77,7 @@ func New(baseURL, key, userAgent string) *Client {
 		BaseURL:   strings.TrimRight(baseURL, "/"),
 		Key:       key,
 		UserAgent: userAgent,
-		HTTP:      &http.Client{Timeout: 10 * time.Minute},
+		HTTP:      NewHTTPClient(),
 	}
 }
 

--- a/internal/api/timeout_test.go
+++ b/internal/api/timeout_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// trickle sends response headers at once, then writes the body in small pieces
+// over the given span. That is what a large file over a slow link looks like:
+// progress is steady, it just takes a while.
+func trickle(t *testing.T, pieces int, gap time.Duration) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server cannot flush")
+			return
+		}
+		for i := 0; i < pieces; i++ {
+			if _, err := w.Write([]byte("chunk")); err != nil {
+				return
+			}
+			flusher.Flush()
+			time.Sleep(gap)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A transfer that keeps making progress must not be cut off, however long it
+// runs. Under a single deadline covering the body this failed part-way with
+// "Client.Timeout ... while reading body", which made the cap a bandwidth floor
+// rather than a liveness check.
+func TestSlowButProgressingTransferIsNotCutOff(t *testing.T) {
+	srv := trickle(t, 6, 40*time.Millisecond)
+	c := newHTTPClient(time.Second, time.Second, 50*time.Millisecond)
+
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if len(body) != 30 {
+		t.Fatalf("read %d bytes (%q), want the whole body", len(body), body)
+	}
+}
+
+// The body is patient, but a server that accepts the connection and then says
+// nothing must still be given up on.
+func TestUnresponsiveServerFailsFast(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open and never write a response.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	c := newHTTPClient(time.Second, time.Second, 100*time.Millisecond)
+	start := time.Now()
+	_, err = c.Get("http://" + ln.Addr().String())
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected the request to fail")
+	}
+	if !strings.Contains(err.Error(), "timeout awaiting response headers") {
+		t.Fatalf("error = %v, want a response-header timeout", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("took %v to give up, want roughly the header timeout", elapsed)
+	}
+}
+
+// The absence of a total deadline is the point of this configuration, so pin it:
+// reintroducing http.Client.Timeout would silently cap transfer size again.
+func TestClientHasNoTotalDeadline(t *testing.T) {
+	c := NewHTTPClient()
+	if c.Timeout != 0 {
+		t.Fatalf("http.Client.Timeout = %v; it covers the response body, so it caps "+
+			"how large a transfer can be at a given bandwidth", c.Timeout)
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", c.Transport)
+	}
+	if tr.ResponseHeaderTimeout != HeaderTimeout {
+		t.Errorf("ResponseHeaderTimeout = %v, want %v", tr.ResponseHeaderTimeout, HeaderTimeout)
+	}
+	if tr.TLSHandshakeTimeout != TLSTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", tr.TLSHandshakeTimeout, TLSTimeout)
+	}
+	if tr.Proxy == nil {
+		t.Error("Proxy is nil; HTTPS_PROXY must keep working")
+	}
+}
+
+// New() must hand its client the same configuration.
+func TestNewUsesTheSharedClient(t *testing.T) {
+	c := New("https://example.test", "ask_x", "ua")
+	if c.HTTP == nil || c.HTTP.Timeout != 0 {
+		t.Fatalf("client HTTP = %+v, want the shared no-total-deadline client", c.HTTP)
+	}
+}


### PR DESCRIPTION
## The problem

Both HTTP clients use `http.Client{Timeout: 10 * time.Minute}` — `internal/api/client.go` and a second copy in `cmd/crypto.go` for the decrypt-from-URL path.

`http.Client.Timeout` covers **reading the response body** (and writing the request body). So it isn't a liveness check, it's a bandwidth floor:

> a 100 MB upload — the documented maximum on Pro — has to sustain about **1.4 Mbit/s** or fail after transferring most of itself

100 MB / 600 s ≈ 175 KB/s. Anything slower — mobile tethering, hotel wifi, a congested CI region — cannot move a max-size file at all, no matter how many times it retries. And the failure arrives *after* ten minutes of transfer, having wasted the bandwidth, with an error that reads like a server fault rather than "your link is too slow for the size you picked".

## Reproduction

Scaled from minutes to milliseconds — a server that sends headers immediately then trickles its body over 240ms, with a 50ms budget:

```
current design (one deadline over the whole exchange)
  slow transfer        FAILED   15 of 30 bytes, "Client.Timeout or context
                                cancellation while reading body"

proposed design (per-phase deadlines)
  same slow transfer   OK       30 bytes
  silent server        FAILED   "timeout awaiting response headers", ~100ms
```

The third line is the point: patience with the body does **not** mean patience with a dead server.

## The change

A transfer that keeps making progress is not broken, so bound the phases *before* any bytes move:

| Phase | Limit |
|---|---|
| TCP connect | 30s |
| TLS handshake | 10s |
| Waiting for response headers | 60s |

A server that is unreachable, or that accepts the connection and then goes quiet, is still given up on quickly — and with a more specific message than a generic deadline.

**What this gives up, stated plainly:** a peer that sends headers and then trickles a byte every few minutes forever will no longer be cut off by a timer. That case is now ended by the peer or the operator — `Ctrl-C`/`SIGTERM` already cancels in-flight requests through the context `Run` wires up. This is the same trade `gh`, `curl` and the AWS CLI make: connect/read-phase timeouts rather than a cap on total transfer time. If you'd rather keep a hard ceiling for CI, a `--timeout` flag defaulting to off is an easy follow-up — I left it out to keep this one change.

## Incidental fix

The transport is now shared via `api.NewHTTPClient()`, so `cmd/crypto.go` stops carrying its own copy of the same client. That copy had no `Proxy` set, so it ignored `HTTPS_PROXY`; fetching a share URL to decrypt now honours proxy settings like every other request does.

## Tests

Four in a new `internal/api/timeout_test.go`:

| Test | Asserts |
|---|---|
| `TestSlowButProgressingTransferIsNotCutOff` | a body trickled well past the header timeout completes |
| `TestUnresponsiveServerFailsFast` | a silent server fails with a header timeout, in roughly the configured time |
| `TestClientHasNoTotalDeadline` | `Timeout == 0`, phase timeouts set, `Proxy` non-nil |
| `TestNewUsesTheSharedClient` | `New()` doesn't reintroduce a total deadline |

`newHTTPClient` takes its timeouts as parameters so the tests run in milliseconds against real servers rather than asserting on struct fields alone.

Against the previous design all three of the meaningful ones fail, with the error a user would actually see:

```
--- FAIL: TestSlowButProgressingTransferIsNotCutOff
    reading body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
--- FAIL: TestClientHasNoTotalDeadline
    http.Client.Timeout = 1m0s; it covers the response body, so it caps how large a
    transfer can be at a given bandwidth
```

`TestClientHasNoTotalDeadline` exists specifically so that reintroducing `http.Client.Timeout` later fails loudly instead of quietly capping transfer size again.

`gofmt`, `go vet ./...`, `go test ./...` clean. `docs/CLI.md` gains a short Timeouts section with the table above.
