### PR TITLE
fix: add Windows npm and release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,9 +186,16 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   verify:
-    name: Verify published package
+    name: Verify published package (${{ matrix.os }})
     needs: [validate, npm]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -205,4 +212,5 @@ jobs:
             fi
             sleep 10
           done
-          test "$(aispace version --json | jq -r .version)" = "$VERSION"
+          ACTUAL_VERSION="$(aispace version --json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version')"
+          test "$ACTUAL_VERSION" = "$VERSION"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -32,6 +33,9 @@ archives:
   - id: tarballs
     ids: [aispace]
     formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     name_template: "aispace_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning, and release entries are derived from the immutable Git tag and GitHu
 - Local age X25519 key generation, encryption, and decryption workflows.
 - Codex-compatible agent skill and agent integration reference.
 - Runnable report-sharing, encrypted-handoff, and CI examples.
+- Windows amd64 and arm64 release binaries with npm installation support.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ brew install aispace-sh/tap/aispace
 go install github.com/aispace-sh/aispace-client@latest
 ```
 
-Pin the shell installer with `AISPACE_VERSION=v1.2.3`. Release binaries support macOS and Linux on
-amd64 and arm64.
+Pin the shell installer with `AISPACE_VERSION=v1.2.3`. Release binaries support macOS, Linux, and
+Windows on amd64 and arm64. The shell installer supports macOS and Linux; use npm on Windows.
 
 <div align="center">
   <a href="https://x.ai/bot/suv5xSPPbQmzi02LF7Z9Z">
@@ -203,8 +203,8 @@ welcome—start with [`CONTRIBUTING.md`](CONTRIBUTING.md), check the [`ROADMAP.m
 review the [`CHANGELOG.md`](CHANGELOG.md). Focused bug reports and feature proposals can use the
 repository's structured issue forms.
 
-Releases are cut through the manual GitHub Actions workflow. GoReleaser builds checksummed macOS and
-Linux binaries, updates the Homebrew tap, and publishes `@aispace-sh/cli` to npm. See
+Releases are cut through the manual GitHub Actions workflow. GoReleaser builds checksummed macOS,
+Linux, and Windows binaries, updates the Homebrew tap, and publishes `@aispace-sh/cli` to npm. See
 [`RELEASE.md`](RELEASE.md) for publisher configuration and the release checklist.
 
 ## Security

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,11 +32,20 @@ downloads the native binary and `checksums.txt` from that GitHub release. GoRele
 
 ## Verify
 
+On macOS or Linux:
+
 ```sh
 npm install -g @aispace-sh/cli
 aispace version
 
 brew install aispace-sh/tap/aispace
+aispace version
+```
+
+On Windows, verify the npm package from PowerShell:
+
+```powershell
+npm install -g @aispace-sh/cli
 aispace version
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ large item helps confirm the intended shape.
 
 ## Now: dependable first release
 
-- Publish signed, checksum-verified binaries for macOS and Linux on amd64 and arm64.
+- Publish checksum-verified binaries for macOS, Linux, and Windows on amd64 and arm64.
 - Publish matching npm and Homebrew packages from the same immutable GitHub release.
 - Keep CLI output, JSON shapes, errors, and exit codes stable and documented.
 - Validate the Codex skill and agent integration examples against the published client.
@@ -14,7 +14,7 @@ large item helps confirm the intended shape.
 ## Next: easier integrations
 
 - Add copyable examples for more CI systems and agent runtimes.
-- Evaluate Windows binaries and a native package-manager channel.
+- Evaluate Windows code signing and a native package-manager channel.
 - Add opt-in shell completion installation.
 - Improve diagnostics for network, quota, and configuration failures.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,6 +17,16 @@ places it in `/usr/local/bin` (or `~/.local/bin` if that is not writable). Overr
 `AISPACE_INSTALL_DIR=/path`. Manual install: download the asset for your platform from
 [GitHub Releases](https://github.com/aispace-sh/aispace-client/releases), `chmod +x`, move to `$PATH`.
 
+On Windows x64 or ARM64, install through npm; it downloads the matching checksummed `.exe` release:
+
+```powershell
+npm install -g @aispace-sh/cli
+aispace version
+```
+
+Windows binaries are checksum-verified but not currently code-signed, so Windows may show a
+SmartScreen warning on first run.
+
 Build from source:
 
 ```sh

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -90,7 +90,7 @@ The URL is always the last output line; `--json` makes the entire exchange machi
 ## Submission checklist
 
 - GitHub release, npm, Homebrew, and shell installer all return the same version.
-- README install commands work on a clean macOS and Linux environment.
+- Applicable README install commands work on clean macOS, Linux, and Windows environments.
 - Social preview is uploaded in GitHub repository settings.
 - Repository description, website, and topics match the canonical wording above.
 - The demo contains no real key, private link, file ID, or encryption identity.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,9 +1,9 @@
 # aispace — secure temporary file sharing for AI agents
 
-Installs the native [`aispace`](https://github.com/aispace-sh/aispace-client) binary for macOS or
-Linux and verifies it against the SHA-256 checksums published with the matching GitHub release.
-The CLI creates expiring and revocable file links, emits predictable JSON for automation, and can
-encrypt files locally with age X25519 before upload.
+Installs the native [`aispace`](https://github.com/aispace-sh/aispace-client) binary for macOS,
+Linux, or Windows and verifies it against the SHA-256 checksums published with the matching GitHub
+release. The CLI creates expiring and revocable file links, emits predictable JSON for automation,
+and can encrypt files locally with age X25519 before upload.
 
 ```sh
 npm install -g @aispace-sh/cli
@@ -11,8 +11,10 @@ aispace login --key ask_...
 aispace upload report.pdf --link --link-expires 1h --json
 ```
 
-Supported platforms: macOS and Linux on x64 or ARM64. Node.js 20 or newer is required for the
-installer and wrapper; the installed Go binary itself has no Node.js runtime dependency.
+Supported platforms: macOS, Linux, and Windows on x64 or ARM64. Node.js 20 or newer is required for
+the installer and wrapper; the installed Go binary itself has no Node.js runtime dependency.
+Windows binaries are checksum-verified but not currently code-signed, so Windows may show a
+SmartScreen warning on first run.
 
 See the [main repository](https://github.com/aispace-sh/aispace-client) for the agent skill,
 encrypted-handoff examples, CLI/API documentation, threat boundaries, and contribution guide.

--- a/npm/bin/aispace.js
+++ b/npm/bin/aispace.js
@@ -3,8 +3,9 @@
 
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');
+const { binaryName } = require('../scripts/install');
 
-const binary = path.join(__dirname, 'aispace');
+const binary = path.join(__dirname, binaryName());
 const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
 if (result.error) {
   console.error(`aispace: ${result.error.message}`);

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -9,10 +9,15 @@ const path = require('node:path');
 const REPOSITORY = 'aispace-sh/aispace-client';
 
 function platformAsset(platform = process.platform, arch = process.arch) {
-  const os = { darwin: 'darwin', linux: 'linux' }[platform];
+  const os = { darwin: 'darwin', linux: 'linux', win32: 'windows' }[platform];
   const cpu = { x64: 'amd64', arm64: 'arm64' }[arch];
   if (!os || !cpu) throw new Error(`unsupported platform: ${platform}/${arch}`);
-  return `aispace_${os}_${cpu}`;
+  const extension = platform === 'win32' ? '.exe' : '';
+  return `aispace_${os}_${cpu}${extension}`;
+}
+
+function binaryName(platform = process.platform) {
+  return platform === 'win32' ? 'aispace.exe' : 'aispace';
 }
 
 function download(url, redirects = 0) {
@@ -45,7 +50,7 @@ function expectedChecksum(checksums, asset) {
 
 async function main() {
   const pkg = require('../package.json');
-  const target = path.join(__dirname, '..', 'bin', 'aispace');
+  const target = path.join(__dirname, '..', 'bin', binaryName());
   if (process.env.AISPACE_NPM_BINARY) {
     fs.copyFileSync(process.env.AISPACE_NPM_BINARY, target);
     fs.chmodSync(target, 0o755);
@@ -70,4 +75,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { expectedChecksum, platformAsset };
+module.exports = { binaryName, expectedChecksum, platformAsset };

--- a/npm/test/install.test.js
+++ b/npm/test/install.test.js
@@ -2,12 +2,21 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { expectedChecksum, platformAsset } = require('../scripts/install');
+const { binaryName, expectedChecksum, platformAsset } = require('../scripts/install');
 
 test('maps supported platforms to release assets', () => {
   assert.equal(platformAsset('darwin', 'arm64'), 'aispace_darwin_arm64');
   assert.equal(platformAsset('linux', 'x64'), 'aispace_linux_amd64');
-  assert.throws(() => platformAsset('win32', 'x64'), /unsupported platform/);
+  assert.equal(platformAsset('win32', 'x64'), 'aispace_windows_amd64.exe');
+  assert.equal(platformAsset('win32', 'arm64'), 'aispace_windows_arm64.exe');
+  assert.throws(() => platformAsset('freebsd', 'x64'), /unsupported platform: freebsd\/x64/);
+  assert.throws(() => platformAsset('linux', 'ia32'), /unsupported platform: linux\/ia32/);
+});
+
+test('uses the Windows executable suffix only on Windows', () => {
+  assert.equal(binaryName('darwin'), 'aispace');
+  assert.equal(binaryName('linux'), 'aispace');
+  assert.equal(binaryName('win32'), 'aispace.exe');
 });
 
 test('extracts only the checksum for the requested asset', () => {


### PR DESCRIPTION
## Summary

- build Windows amd64 and arm64 binaries with GoReleaser, publishing raw executable assets for npm and ZIP archives for manual installation
- make the npm installer download checksummed Windows executables and make the launcher execute aispace.exe on Windows
- verify the published npm package on both Ubuntu and Windows in the release workflow
- document Windows installation, architecture support, and the current SmartScreen/code-signing limitation

## Verification

- official GoReleaser v2.18.1 snapshot produced aispace_windows_amd64.exe, aispace_windows_arm64.exe, and matching ZIP/checksum artifacts
- both Windows architectures cross-compiled successfully
- go test -race ./...
- go vet ./...
- npm test
- npm pack --dry-run
- JavaScript, YAML, shell, formatting, and diff checks

Closes #5