### PR TITLE
fix(decrypt): identity permission warning fires on every decrypt on Windows

### DIFF
--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"filippo.io/age"
@@ -308,8 +309,14 @@ func (a *app) runDecrypt(ctx context.Context, input string, f decryptFlags) erro
 func (a *app) loadIdentity(path string) (age.Identity, error) {
 	var raw string
 	if path != "" {
-		if info, err := os.Stat(path); err == nil && info.Mode().Perm()&0o077 != 0 {
-			fmt.Fprintf(a.stderr, "warning: identity file %s is readable by other users; run chmod 600 %s\n", path, path)
+		// Windows has no Unix permission bits: os.Stat reports 0666 for every
+		// file, so this would warn on every decrypt and tell the user to run a
+		// command they do not have. config.Load skips its own permission
+		// warning there for the same reason.
+		if runtime.GOOS != "windows" {
+			if info, err := os.Stat(path); err == nil && info.Mode().Perm()&0o077 != 0 {
+				fmt.Fprintf(a.stderr, "warning: identity file %s has permissions %04o, expected 0600 (run: chmod 600 %s)\n", path, info.Mode().Perm(), path)
+			}
 		}
 		b, err := os.ReadFile(path)
 		if err != nil {

--- a/cmd/identity_perm_test.go
+++ b/cmd/identity_perm_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+)
+
+const looseIdentityWarning = "identity file"
+
+// encryptTo writes an age file for id and returns its path.
+func encryptTo(t *testing.T, dir, name, plaintext string, r age.Recipient) string {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(w, plaintext); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// An identity file with the permissions the CLI itself writes must not be
+// reported as loose. On Windows os.Stat reports 0666 for every file, so the
+// unguarded check warned on every decrypt and told the user to run chmod.
+func TestDecryptDoesNotWarnAboutCorrectlyPermissionedIdentity(t *testing.T) {
+	isolate(t)
+	dir := t.TempDir()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := encryptTo(t, dir, "secret.age", "payload", id.Recipient())
+
+	key := filepath.Join(dir, "secret.agekey")
+	if err := os.WriteFile(key, []byte(id.String()+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := run("", "decrypt", enc, "--identity-file", key, "--output", filepath.Join(dir, "out.txt"))
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	if strings.Contains(r.stderr, looseIdentityWarning) {
+		t.Fatalf("warned about a mode-0600 identity file: %q", r.stderr)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "out.txt"))
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("plaintext = %q err=%v", got, err)
+	}
+}
+
+// Where the bits are real, a genuinely world-readable identity must still warn.
+func TestDecryptWarnsAboutLooseIdentityPermissions(t *testing.T) {
+	if !permBits {
+		t.Skip("Unix permission bits are not implemented on this platform")
+	}
+	isolate(t)
+	dir := t.TempDir()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := encryptTo(t, dir, "secret.age", "payload", id.Recipient())
+
+	key := filepath.Join(dir, "secret.agekey")
+	if err := os.WriteFile(key, []byte(id.String()+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(key, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := run("", "decrypt", enc, "--identity-file", key, "--output", filepath.Join(dir, "out.txt"))
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	if !strings.Contains(r.stderr, looseIdentityWarning) || !strings.Contains(r.stderr, "0644") {
+		t.Fatalf("expected a warning naming the mode, got %q", r.stderr)
+	}
+}


### PR DESCRIPTION
Found while probing `decrypt` on Windows — newly relevant since #13 made it a shipped platform.

## The bug

`loadIdentity` warns when an identity file is readable by other users:

```go
if info, err := os.Stat(path); err == nil && info.Mode().Perm()&0o077 != 0 {
```

Windows cannot answer that question. There are no Unix permission bits, and `os.Stat` reports `0666` for every file — so the condition is **always true** there. The warning fires on every single decrypt, including for the mode-0600 file the CLI itself just wrote with `--identity-out`:

```
$ aispace decrypt secret.age --identity-file secret.agekey --output secret.pdf
warning: identity file secret.agekey is readable by other users; run chmod 600 secret.agekey
decrypted secret.age -> secret.pdf
```

Two problems beyond the noise:

- **The advice is unusable.** `chmod` is not a Windows command, so there is no action the reader can take.
- **A warning that is always wrong is worse than no warning.** It trains the reader to skip past it, which costs them the one case where the file genuinely is exposed. This is a security warning, so that erosion is the real damage.

## The fix

`internal/config/config.go` already guards the identical check:

```go
if runtime.GOOS != "windows" && st.Mode().Perm()&0o077 != 0 {
```

This applies the same guard to the only other place the pattern appears, so the two cannot drift on what a permission warning means. Both files now agree.

While there, the message adopts the config wording and reports the mode it actually found:

```
warning: identity file secret.agekey has permissions 0644, expected 0600 (run: chmod 600 secret.agekey)
```

Being told *how far off* it is beats being told to fix something unspecified — and if the mode ever looks surprising, it is now visible in the warning itself.

## Tests

Two in a new `cmd/identity_perm_test.go`:

- `TestDecryptDoesNotWarnAboutCorrectlyPermissionedIdentity` — a mode-0600 identity produces no warning, and the plaintext still comes out right. This is the one that was failing on Windows.
- `TestDecryptWarnsAboutLooseIdentityPermissions` — where the bits are real, a `0644` identity **still warns** and names the mode. Skipped on Windows via the existing `permBits`, so the fix cannot be mistaken for "delete the warning".

Against `main` the first fails on Windows with exactly the message users see:

```
--- FAIL: TestDecryptDoesNotWarnAboutCorrectlyPermissionedIdentity
    warned about a mode-0600 identity file: "warning: identity file ...secret.agekey is
    readable by other users; run chmod 600 ...secret.agekey"
```

`gofmt`, `go vet ./...` and `go test ./...` clean on Windows.
