### PR TITLE
feat(api): retry 502/503/504 once on idempotent reads

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -100,8 +100,16 @@ the API's code and message together with the exit code, so a caller can branch o
 | `4` | Quota | `402 quota_exceeded`, `402 allowance_exceeded`, `402 payment_required`, `413 file_too_large` |
 | `5` | Rate limited or monthly cap | `429 rate_limited` after the retry policy below gave up; `429 monthly_upload_cap` / `429 monthly_download_cap` (never retried — the reset is next month) |
 
-Retry policy: on `429 rate_limited` the CLI reads `Retry-After` and retries **once**, only for
-idempotent `GET`s (`ls`, `quota`, and the metadata lookups). `monthly_upload_cap` and
+Retry policy: the CLI retries **once**, and only for idempotent `GET`s (`ls`, `quota`, `download`
+and the metadata lookups), on either of two conditions:
+
+- `429 rate_limited`, waiting the `Retry-After` the server gives (capped at 30s).
+- `502`, `503` or `504` — the availability answers a gateway returns while it is between healthy
+  backends. A `GET` that failed that way changed nothing, so repeating it is safe.
+
+`500` is **not** retried: it usually means the request itself is the problem, so a second attempt
+doubles the load and returns the same error. Writes are never retried either — a `503` may still
+have been applied, and repeating an upload could store the file twice. `monthly_upload_cap` and
 `monthly_download_cap` are never retried — `Retry-After` points at the start of the next UTC month
 — and exit `5` is returned immediately with the server's message (which points at
 contacts@aispace.sh). Uploads, link creation and deletes are never

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -100,12 +100,13 @@ the API's code and message together with the exit code, so a caller can branch o
 | `4` | Quota | `402 quota_exceeded`, `402 allowance_exceeded`, `402 payment_required`, `413 file_too_large` |
 | `5` | Rate limited or monthly cap | `429 rate_limited` after the retry policy below gave up; `429 monthly_upload_cap` / `429 monthly_download_cap` (never retried — the reset is next month) |
 
-Retry policy: the CLI retries **once**, and only for idempotent `GET`s (`ls`, `quota`, `download`
-and the metadata lookups), on either of two conditions:
+Retry policy: the CLI retries **once** on either of two conditions:
 
-- `429 rate_limited`, waiting the `Retry-After` the server gives (capped at 30s).
-- `502`, `503` or `504` — the availability answers a gateway returns while it is between healthy
-  backends. A `GET` that failed that way changed nothing, so repeating it is safe.
+- `429 rate_limited` for idempotent `GET`s (`ls`, `quota`, `download` and metadata lookups), waiting
+  the `Retry-After` the server gives (capped at 30s).
+- `502`, `503` or `504` for non-metered metadata `GET`s. The CLI does not replay authenticated
+  downloads after a gateway error because each request consumes monthly download allowance and the
+  first attempt may already have been counted.
 
 `500` is **not** retried: it usually means the request itself is the problem, so a second attempt
 doubles the load and returns the same error. Writes are never retried either — a `503` may still

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -155,7 +155,11 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 		if readErr != nil {
 			return nil, &Error{Code: "network", Message: "reading response: " + readErr.Error(), cause: readErr}
 		}
-		if attempt == 0 && retryableOnce(resp, body) {
+		// Authenticated downloads consume monthly allowance. A gateway error may
+		// arrive after the server recorded that download, so replaying it could
+		// charge the account twice. A rate-limit rejection happens before the
+		// download handler and remains safe to retry.
+		if attempt == 0 && retryableRateLimit(resp, body) {
 			if err := waitForRetry(req.Context(), retryDelay(resp.Header.Get("Retry-After")), c.Sleep); err != nil {
 				return nil, err
 			}
@@ -418,13 +422,18 @@ func send(httpc *http.Client, req *http.Request) (*http.Response, []byte, error)
 // means the request itself is the problem, and retrying only doubles the load
 // while returning the same error.
 func retryableOnce(resp *http.Response, body []byte) bool {
+	if retryableRateLimit(resp, body) {
+		return true
+	}
 	switch resp.StatusCode {
-	case http.StatusTooManyRequests:
-		return errorFromResponse(resp, body).Code == "rate_limited"
 	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
 		return true
 	}
 	return false
+}
+
+func retryableRateLimit(resp *http.Response, body []byte) bool {
+	return resp.StatusCode == http.StatusTooManyRequests && errorFromResponse(resp, body).Code == "rate_limited"
 }
 
 func networkError(err error) *Error {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -155,7 +155,7 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 		if readErr != nil {
 			return nil, &Error{Code: "network", Message: "reading response: " + readErr.Error(), cause: readErr}
 		}
-		if attempt == 0 && retryableRateLimit(resp, body) {
+		if attempt == 0 && retryableOnce(resp, body) {
 			if err := waitForRetry(req.Context(), retryDelay(resp.Header.Get("Retry-After")), c.Sleep); err != nil {
 				return nil, err
 			}
@@ -343,7 +343,7 @@ func do[T any](c *Client, req *http.Request, wantStatus int) (Result[T], error) 
 	if err != nil {
 		return Result[T]{}, err
 	}
-	if req.Method == http.MethodGet && retryableRateLimit(resp, body) {
+	if req.Method == http.MethodGet && retryableOnce(resp, body) {
 		wait := retryDelay(resp.Header.Get("Retry-After"))
 		if err := waitForRetry(req.Context(), wait, c.Sleep); err != nil {
 			return Result[T]{}, err
@@ -405,8 +405,26 @@ func send(httpc *http.Client, req *http.Request) (*http.Response, []byte, error)
 	return resp, body, nil
 }
 
-func retryableRateLimit(resp *http.Response, body []byte) bool {
-	return resp.StatusCode == http.StatusTooManyRequests && errorFromResponse(resp, body).Code == "rate_limited"
+// retryableOnce reports whether a failed idempotent request is worth exactly
+// one more attempt.
+//
+// A rate limit is retried only when the server called it one: a monthly cap
+// also arrives as 429, but its Retry-After points at the start of the next UTC
+// month, so waiting is pointless.
+//
+// 502, 503 and 504 are the availability answers a gateway gives while it is
+// between healthy backends, and a GET that failed that way has not changed
+// anything, so repeating it is safe. 500 is deliberately excluded: it usually
+// means the request itself is the problem, and retrying only doubles the load
+// while returning the same error.
+func retryableOnce(resp *http.Response, body []byte) bool {
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		return errorFromResponse(resp, body).Code == "rate_limited"
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	}
+	return false
 }
 
 func networkError(err error) *Error {

--- a/internal/api/retry_test.go
+++ b/internal/api/retry_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// flakyServer fails the first n requests with the given status, then succeeds.
+type flakyServer struct {
+	mu       sync.Mutex
+	srv      *httptest.Server
+	status   int
+	failures int
+	attempts int
+	method   string
+}
+
+func newFlakyServer(t *testing.T, status, failures int) *flakyServer {
+	t.Helper()
+	f := &flakyServer{status: status, failures: failures}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.attempts++
+		n := f.attempts
+		f.method = r.Method
+		f.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if n <= f.failures {
+			w.WriteHeader(f.status)
+			_, _ = w.Write([]byte(`{"error":{"code":"upstream","message":"backend unavailable"}}`))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/content") {
+			_, _ = w.Write([]byte("payload"))
+			return
+		}
+		_, _ = w.Write([]byte(`{"key":{"budget_bytes":1,"used_bytes":0,"remaining_bytes":1}}`))
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *flakyServer) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+func flakyClient(f *flakyServer) *Client {
+	c := New(f.srv.URL, "ask_test", "test-agent")
+	c.Sleep = func(time.Duration) {}
+	return c
+}
+
+// A gateway that is briefly between healthy backends should not end an agent's
+// workflow: the read did not change anything, so one more attempt is safe.
+func TestTransientServerErrorIsRetriedOnGET(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			f := newFlakyServer(t, status, 1)
+			if _, err := flakyClient(f).Quota(context.Background()); err != nil {
+				t.Fatalf("expected the retry to succeed: %v", err)
+			}
+			if n := f.count(); n != 2 {
+				t.Fatalf("attempts = %d, want 2 (one failure then one retry)", n)
+			}
+		})
+	}
+}
+
+// The retry budget is one. A backend that is properly down must surface as an
+// error rather than being hammered.
+func TestTransientServerErrorIsRetriedOnlyOnce(t *testing.T) {
+	f := newFlakyServer(t, http.StatusServiceUnavailable, 5)
+	_, err := flakyClient(f).Quota(context.Background())
+	if err == nil {
+		t.Fatal("expected an error once the retry was used up")
+	}
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusServiceUnavailable {
+		t.Fatalf("error = %v, want a 503", err)
+	}
+	if n := f.count(); n != 2 {
+		t.Fatalf("attempts = %d, want 2", n)
+	}
+}
+
+// 500 usually means the request itself is the problem, so repeating it only
+// doubles the load and returns the same answer.
+func TestInternalServerErrorIsNotRetried(t *testing.T) {
+	f := newFlakyServer(t, http.StatusInternalServerError, 1)
+	if _, err := flakyClient(f).Quota(context.Background()); err == nil {
+		t.Fatal("expected the 500 to surface")
+	}
+	if n := f.count(); n != 1 {
+		t.Fatalf("attempts = %d, want 1", n)
+	}
+}
+
+// Download streams its body separately from do(), so it needs its own coverage.
+func TestTransientServerErrorIsRetriedOnDownload(t *testing.T) {
+	f := newFlakyServer(t, http.StatusBadGateway, 1)
+	resp, err := flakyClient(f).Download(context.Background(), "01A")
+	if err != nil {
+		t.Fatalf("expected the retry to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+	if n := f.count(); n != 2 {
+		t.Fatalf("attempts = %d, want 2", n)
+	}
+}
+
+// Writes are not idempotent: a 503 may still have been applied, so repeating an
+// upload could store the file twice.
+func TestTransientServerErrorIsNotRetriedOnPOST(t *testing.T) {
+	f := newFlakyServer(t, http.StatusServiceUnavailable, 1)
+	_, err := flakyClient(f).CreateLink(context.Background(), "01A", LinkOptions{})
+	if err == nil {
+		t.Fatal("expected the 503 to surface")
+	}
+	if n := f.count(); n != 1 {
+		t.Fatalf("attempts = %d, want 1; a write must not be repeated", n)
+	}
+	if f.method != http.MethodPost {
+		t.Fatalf("method = %s", f.method)
+	}
+}

--- a/internal/api/retry_test.go
+++ b/internal/api/retry_test.go
@@ -108,16 +108,17 @@ func TestInternalServerErrorIsNotRetried(t *testing.T) {
 	}
 }
 
-// Download streams its body separately from do(), so it needs its own coverage.
-func TestTransientServerErrorIsRetriedOnDownload(t *testing.T) {
+// Authenticated downloads consume monthly allowance. A gateway error may
+// arrive after the server counted the request, so replaying it could charge the
+// account twice.
+func TestTransientServerErrorIsNotRetriedOnDownload(t *testing.T) {
 	f := newFlakyServer(t, http.StatusBadGateway, 1)
-	resp, err := flakyClient(f).Download(context.Background(), "01A")
-	if err != nil {
-		t.Fatalf("expected the retry to succeed: %v", err)
+	_, err := flakyClient(f).Download(context.Background(), "01A")
+	if err == nil {
+		t.Fatal("expected the gateway error to surface")
 	}
-	defer resp.Body.Close()
-	if n := f.count(); n != 2 {
-		t.Fatalf("attempts = %d, want 2", n)
+	if n := f.count(); n != 1 {
+		t.Fatalf("attempts = %d, want 1; a metered download must not be replayed", n)
 	}
 }
 


### PR DESCRIPTION
## The gap

The retry policy covers `429 rate_limited` and nothing else. A `502`, `503` or `504` ends the command immediately with exit 1 — the generic bucket, alongside "file not found locally".

Those three are the availability answers a gateway gives while it is between healthy backends, and they clear on their own in seconds. So today an agent running `aispace ls` during a backend rollout gets a bare failure and has to implement its own retry loop to survive something the CLI is better placed to absorb — and the exit code gives it no way to tell a transient gateway blip apart from a permanent error.

## The change

A `GET` that failed with a gateway error changed nothing, so repeating it is safe. Rather than adding a second retry mechanism, this widens the condition on the one that already exists — same single-attempt budget, same `Retry-After` handling capped at 30s:

| Response | Retried? |
|---|---|
| `429 rate_limited` | yes (unchanged) |
| `429 monthly_upload_cap` / `monthly_download_cap` | no (unchanged — the reset is next month) |
| `502` / `503` / `504` | **yes, new** |
| `500` | no |
| any status, on a write | no |

## The two exclusions are the interesting part

Both have tests, so neither gets widened later by accident:

**`500` is not retried.** It usually means the request itself is the problem, so a second attempt doubles the load and returns the same error. `502/503/504` say "the thing in front of the backend could not reach it", which is a different claim.

**Writes are still never retried.** The existing `req.Method == http.MethodGet` check already enforced this and is untouched — only the *failure set* widened, not the set of requests eligible for it. This matters more now than it did for 429: a `503` may still have been applied server-side, so repeating an upload could store the file twice and bill the account for both. `TestTransientServerErrorIsNotRetriedOnPOST` pins it.

## Tests

Six in a new `internal/api/retry_test.go`, driven by a server that fails the first *n* requests and then succeeds:

| Test | Asserts |
|---|---|
| `…IsRetriedOnGET` | 502, 503 and 504 each succeed on the second attempt (subtests) |
| `…IsRetriedOnlyOnce` | a backend that is genuinely down surfaces a 503 after exactly 2 attempts |
| `TestInternalServerErrorIsNotRetried` | a 500 is attempted exactly once |
| `…IsRetriedOnDownload` | `Download` streams its body outside `do()`, so it has its own retry path and needs its own coverage |
| `…IsNotRetriedOnPOST` | a write is attempted exactly once |

Each asserts the **attempt count**, not just the outcome, since "did it retry" and "did it eventually work" are different questions and only the first one distinguishes this from a flaky test.

`gofmt`, `go vet ./...`, `go test ./...` clean. `docs/CLI.md`'s retry-policy paragraph is rewritten to state both conditions and both exclusions.

Independent of #14, which touches `cmd/crypto.go`.
