### PR TITLE
fix: align client with server API contract

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -126,7 +126,7 @@ func (f *fakeServer) handle(w http.ResponseWriter, r *http.Request) {
 	case r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/v1/links/"):
 		w.WriteHeader(204)
 	case r.Method == "GET" && r.URL.Path == "/v1/quota":
-		_, _ = w.Write([]byte(`{"key":{"budget_bytes":52428800,"used_bytes":1048576,"remaining_bytes":51380224},"account":{"allowance_bytes":104857600,"used_bytes":3145728,"remaining_bytes":101711872,"plan":"free","extra_blocks":0},"limits":{"max_file_bytes":26214400,"max_file_ttl_seconds":2592000,"max_link_ttl_seconds":604800,"uploads_per_hour":60,"uploads_per_day":500,"requests_per_minute":300},"rate":{"uploads_hour_remaining":58,"uploads_day_remaining":490,"requests_minute_remaining":299}}`))
+		_, _ = w.Write([]byte(`{"key":{"budget_bytes":52428800,"used_bytes":1048576,"remaining_bytes":51380224},"account":{"allowance_bytes":104857600,"used_bytes":3145728,"remaining_bytes":101711872,"plan":"free","extra_blocks":0},"month":{"uploads_used":12,"uploads_limit":100,"downloads_used":340,"downloads_limit":1000,"period_end":1759276800},"limits":{"max_file_bytes":26214400,"max_file_ttl_seconds":2592000,"max_link_ttl_seconds":604800,"uploads_per_hour":60,"uploads_per_day":500,"requests_per_minute":300},"rate":{"uploads_hour_remaining":58,"uploads_day_remaining":490,"requests_minute_remaining":299}}`))
 	default:
 		w.WriteHeader(404)
 		_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"no route"}}`))
@@ -796,6 +796,7 @@ func TestUploadQuotaAndSizeErrors(t *testing.T) {
 	}{
 		{402, `{"error":{"code":"quota_exceeded","message":"Key budget exceeded","details":{"remaining":0}}}`, "quota_exceeded"},
 		{402, `{"error":{"code":"allowance_exceeded","message":"Account allowance exceeded"}}`, "allowance_exceeded"},
+		{400, `{"error":{"code":"file_too_large","message":"Max 25 MB"}}`, "file_too_large"},
 		{413, `{"error":{"code":"file_too_large","message":"Max 25 MB"}}`, "file_too_large"},
 	} {
 		f.fail = func(r *http.Request) (int, string) { return tc.status, tc.body }
@@ -976,6 +977,7 @@ func TestQuota(t *testing.T) {
 	for _, want := range []string{
 		"key: used 1.0 MB of 50.0 MB, 49.0 MB remaining",
 		"account: used 3.0 MB of 100.0 MB, 97.0 MB remaining, plan free (extra blocks 0)",
+		"month: uploads 12/100, downloads 340/1000, resets 2025-10-01T00:00:00Z",
 		"limits: max file 25.0 MB, max file ttl 30d, max link ttl 7d, uploads 60/h 500/d, requests 300/min",
 		"rate: uploads remaining 58 this hour, 490 today; requests remaining 299 this minute",
 	} {

--- a/cmd/download_verify_test.go
+++ b/cmd/download_verify_test.go
@@ -119,8 +119,8 @@ func TestDownloadVerifyRemovesCorruptOutput(t *testing.T) {
 	}
 }
 
-// Without a recorded digest there is nothing to compare against; say so instead
-// of reporting success for a check that never happened.
+// A compatible server records every digest. If one is absent, refuse the
+// incomplete response instead of reporting success for a check that never ran.
 func TestDownloadVerifyRefusesWhenNoDigestRecorded(t *testing.T) {
 	isolate(t)
 	v := newVerifyServer(t, "contents", "")

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -27,9 +27,8 @@ func (a *app) downloadCmd() *cobra.Command {
 		Long: "Downloads a file this key owns or that is shared with the account, using key\n" +
 			"authentication rather than a public link.\n\n" +
 			"With --verify the bytes are hashed as they are written and compared with the\n" +
-			"SHA-256 the API recorded for the file. That costs one extra metadata request, and\n" +
-			"only works for files uploaded with --sha256, because otherwise there is no\n" +
-			"recorded digest to compare against.",
+			"SHA-256 the API records for every file. That costs one extra metadata request.\n" +
+			"A response without a digest is rejected as incomplete server metadata.",
 		Example: "  aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf --verify",
 		Args:    exactArgs(1, "<file_id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -57,7 +56,7 @@ func (a *app) downloadCmd() *cobra.Command {
 				if want = res.Value.SHA256; want == "" {
 					return &codedError{
 						code: "no_checksum",
-						err:  fmt.Errorf("file %s has no recorded SHA-256 to verify against; it was uploaded without --sha256", id),
+						err:  fmt.Errorf("file %s has no recorded SHA-256 to verify against; the server returned incomplete metadata", id),
 						exit: ExitGeneric,
 					}
 				}
@@ -427,6 +426,7 @@ func (a *app) quotaCmd() *cobra.Command {
 			q := res.Value
 			fmt.Fprintf(a.stdout, "key: used %s of %s, %s remaining\n", fmtBytes(q.Key.UsedBytes), fmtBytes(q.Key.BudgetBytes), fmtBytes(q.Key.RemainingBytes))
 			fmt.Fprintf(a.stdout, "account: used %s of %s, %s remaining, plan %s (extra blocks %d)\n", fmtBytes(q.Account.UsedBytes), fmtBytes(q.Account.AllowanceBytes), fmtBytes(q.Account.RemainingBytes), q.Account.Plan, q.Account.ExtraBlocks)
+			fmt.Fprintf(a.stdout, "month: uploads %d/%d, downloads %d/%d, resets %s\n", q.Month.UploadsUsed, q.Month.UploadsLimit, q.Month.DownloadsUsed, q.Month.DownloadsLimit, fmtTime(q.Month.PeriodEnd))
 			fmt.Fprintf(a.stdout, "limits: max file %s, max file ttl %s, max link ttl %s, uploads %d/h %d/d, requests %d/min\n", fmtBytes(q.Limits.MaxFileBytes), fmtSeconds(q.Limits.MaxFileTTLSeconds), fmtSeconds(q.Limits.MaxLinkTTLSeconds), q.Limits.UploadsPerHour, q.Limits.UploadsPerDay, q.Limits.RequestsPerMinute)
 			fmt.Fprintf(a.stdout, "rate: uploads remaining %d this hour, %d today; requests remaining %d this minute\n", q.Rate.UploadsHourRemaining, q.Rate.UploadsDayRemaining, q.Rate.RequestsMinuteRemaining)
 			return nil

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,7 +45,8 @@ curl -fsS -X POST https://aispace.sh/v1/files \
 Optional headers are `X-Expires-In`, `X-SHA256`, and `X-File-Visibility`. Visibility may be
 `private` or `account`; when omitted, the account's key-sharing setting applies. Account sharing
 does not create a public URL. The server requires `Content-Length` and
-returns the stored file metadata as JSON.
+returns the stored file metadata as JSON. It records a SHA-256 for every upload; `X-SHA256` is an
+optional client-provided expectation that makes the server reject a body whose digest differs.
 
 Public access always requires the separate, explicit link-creation endpoint below.
 
@@ -69,6 +70,9 @@ the service retains only a token hash.
 `429` responses include `Retry-After`. The CLI retries one idempotent read at most once and does not
 retry uploads, deletes, link creation, or monthly-cap failures. Effective limits are returned by
 `GET /v1/quota`; clients should not hard-code plan values.
+
+The quota response contains `key`, `account`, `month`, `limits`, and `rate`. The account-wide
+`month` block reports upload/download usage and limits plus `period_end`, the next UTC reset.
 
 For exact request and response types, see [`internal/api/types.go`](../internal/api/types.go) and
 [`internal/api/client.go`](../internal/api/client.go), which are the executable client contract.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -97,7 +97,7 @@ the API's code and message together with the exit code, so a caller can branch o
 | `1` | Generic failure | Network error, 5xx, unexpected response, file not found locally |
 | `2` | Usage error | Bad flag, missing argument, unparsable duration, control character in the key, `--name` or `--content-type` |
 | `3` | Authentication | No key configured, `401 invalid_key`, `401 key_revoked` |
-| `4` | Quota | `402 quota_exceeded`, `402 allowance_exceeded`, `402 payment_required`, `413 file_too_large` |
+| `4` | Quota | `402 quota_exceeded`, `402 allowance_exceeded`, `402 payment_required`, `400` or `413 file_too_large` |
 | `5` | Rate limited or monthly cap | `429 rate_limited` after the retry policy below gave up; `429 monthly_upload_cap` / `429 monthly_download_cap` (never retried — the reset is next month) |
 
 Retry policy: the CLI retries **once** on either of two conditions:
@@ -138,8 +138,9 @@ A stalled transfer is therefore ended by the peer or by the operator, not by a t
 ## Durations
 
 Flags that take a duration accept Go-style strings with an added `d` unit: `30s`, `15m`, `1h`,
-`36h`, `7d`. Plain integers are seconds. The server clamps values to its maxima
-(files and links both cap at 7d on Free and 30d on Paid, and a link never outlives its file) and the CLI prints the effective value it got back.
+`36h`, `7d`. Plain integers are seconds. File lifetimes above the plan maximum are rejected;
+links are clamped to their plan maximum and never outlive their file. Both cap at 7d on Free and
+30d on Paid, and the CLI prints the effective expiry returned by the server.
 
 ## Commands
 
@@ -273,11 +274,10 @@ aispace download 01J8ZQ3V9N7X2K4M6P8R0T2W4Y --output report.pdf --verify
 ```
 
 `--verify` hashes the bytes as they are written and compares the result with the SHA-256 the API
-recorded for the file, so a truncated or altered transfer is caught rather than trusted. It reads
-the file's metadata first, which costs **one extra request** against the per-minute rate limit, and
-only works for files uploaded with `--sha256` — without a recorded digest there is nothing to
-compare against and the command exits 1 with `no_checksum` rather than reporting a check it did
-not perform.
+records for every uploaded file, so a truncated or altered transfer is caught rather than trusted.
+It reads the file's metadata first, which costs **one extra request** against the per-minute rate
+limit. An incomplete or incompatible server response without a digest exits 1 with `no_checksum`
+rather than reporting a check it did not perform.
 
 On a mismatch the exit code is 1 with `checksum_mismatch`, and the output file is removed, so a
 caller that ignores the exit code cannot pick up a corrupt file. With `--output -` the bytes have
@@ -454,24 +454,25 @@ File metadata (`GET /v1/files/:id`).
 aispace quota [--json]
 ```
 
-Four lines, one per group:
+Five lines, one per group:
 
 ```
 key: used 1.0 MB of 50.0 MB, 49.0 MB remaining
 account: used 3.0 MB of 100.0 MB, 97.0 MB remaining, plan free (extra blocks 0)
+month: uploads 12/100, downloads 340/1000, resets 2025-10-01T00:00:00Z
 limits: max file 25.0 MB, max file ttl 30d, max link ttl 7d, uploads 60/h 500/d, requests 300/min
 rate: uploads remaining 58 this hour, 490 today; requests remaining 299 this minute
 ```
 
-The typed response is `key`, `account`, `limits` and `rate` — see
-[`internal/api/types.go`](../internal/api/types.go), which `docs/API.md` names as the client
-contract. The account-wide monthly caps are not part of it: they surface as
-`429 monthly_upload_cap` / `429 monthly_download_cap` errors, which are never retried because the
-reset is the start of the next UTC month.
+The typed response is `key`, `account`, `month`, `limits` and `rate` — see
+[`internal/api/types.go`](../internal/api/types.go). Monthly counters are account-wide and reset at
+`month.period_end`. Exhaustion surfaces as `429 monthly_upload_cap` or
+`429 monthly_download_cap` and is never retried automatically.
 
 ```sh
 aispace quota --json | jq '.key.remaining_bytes'
 aispace quota --json | jq -e '.rate.uploads_hour_remaining > 0' >/dev/null || echo "wait"
+aispace quota --json | jq '.month | {uploads_left: (.uploads_limit - .uploads_used), downloads_left: (.downloads_limit - .downloads_used), period_end}'
 
 # largest file this account may upload right now
 aispace quota --json | jq '[.limits.max_file_bytes, .account.remaining_bytes] | min'

--- a/docs/LLM_USAGE.md
+++ b/docs/LLM_USAGE.md
@@ -25,9 +25,10 @@ long or too structured for chat (reports, tables, code bundles, images).
   free plan and 30 days on Pro. Never promise permanence.
 - Before uploading anything large, or before a batch of uploads, run `aispace quota --json` and
   check `.limits.max_file_bytes`, `.key.remaining_bytes`, `.account.remaining_bytes` and the
-  short-window counters `.rate.uploads_hour_remaining` / `.rate.uploads_day_remaining`.
-- The account-wide monthly cap is not reported by `quota`; it appears only as a `429` with code
-  `monthly_upload_cap` or `monthly_download_cap` when you hit it.
+  short-window counters `.rate.uploads_hour_remaining` / `.rate.uploads_day_remaining`, plus
+  `.month.uploads_used < .month.uploads_limit`.
+- Check `.month.uploads_used` / `.month.uploads_limit` and the corresponding download fields before
+  large workflows. `.month.period_end` is the next UTC reset.
 - Exit codes: 2 = bad input, fix the arguments and do not retry unchanged; 3 = key problem (stop
   and tell the user); 4 = storage quota exceeded (tell the user, do not retry); 5 = rate limited
   or the monthly cap is used up.
@@ -90,7 +91,7 @@ Anthropic `tools[]` entries (rename `parameters` → `input_schema` for Anthropi
         "content": { "type": "string", "description": "UTF-8 text content to upload. Provide either content or path." },
         "path": { "type": "string", "description": "Path to an existing local file to upload. Provide either content or path." },
         "content_type": { "type": "string", "description": "MIME type. Defaults from the extension." },
-        "expires": { "type": "string", "description": "File lifetime such as 1h, 3d, 7d. Maximum 7d on the free plan, 30d on Pro; longer values are clamped. Default 7d.", "default": "7d" },
+        "expires": { "type": "string", "description": "File lifetime such as 1h, 3d, 7d. Maximum 7d on the free plan, 30d on Pro; longer values are rejected. Default 7d.", "default": "7d" },
         "link": { "type": "boolean", "description": "Also create a public share link. Enable only when sharing outside the account is requested.", "default": false },
         "link_expires": { "type": "string", "description": "Link lifetime such as 15m, 1h, 24h. Maximum 7d on the free plan and 30d on paid, and never past the file's own expiry; longer values are clamped. Default 1h.", "default": "1h" },
         "max_downloads": { "type": "integer", "minimum": 1, "description": "Optional cap on downloads for the link. Use 1 for sensitive one-shot delivery." },
@@ -242,7 +243,7 @@ Rules of thumb:
 - Everything is gone after at most 7 days (free) or 30 days (Pro). Say so when handing over
   anything the user might want to keep ("download it before Friday"). Read
   `limits.max_file_ttl_seconds` from `aispace quota --json` rather than assuming 30 days: on the
-  free plan a `--expires 30d` is clamped to 7 d.
+  free plan a `--expires 30d` is rejected; request no more than the reported maximum.
 - **Every download counts** against the account's monthly download cap (1,000 free, 100,000 per
   Pro block), so do not hand the same link to a system that polls it. One deliberate download per
   recipient is the intent.
@@ -250,8 +251,8 @@ Rules of thumb:
 ## Checking upload capacity before a big upload or batch
 
 Uploads can be refused for **bytes** (`402`, storage), short-window rate limits (`429`), or the
-account-wide monthly count (`429 monthly_upload_cap`). A `quota` GET can pre-check storage and the
-short-window limits, but the monthly cap is reported only when an upload reaches it:
+account-wide monthly count (`429 monthly_upload_cap`). A `quota` GET can pre-check storage,
+short-window limits, and the monthly cap:
 
 ```sh
 need=2097152    # 2 MB
@@ -259,6 +260,7 @@ aispace quota --json | jq -e --argjson n "$need" '
   .limits.max_file_bytes >= $n
   and .key.remaining_bytes >= $n
   and .account.remaining_bytes >= $n
+  and .month.uploads_used < .month.uploads_limit
   and .rate.uploads_hour_remaining > 0
   and .rate.uploads_day_remaining > 0' >/dev/null || { echo "cannot upload $need bytes now"; aispace quota; exit 4; }
 ```
@@ -270,14 +272,15 @@ n=250; total=52428800   # 250 files, 50 MB together
 aispace quota --json | jq -e --argjson n "$n" --argjson t "$total" '
   .key.remaining_bytes >= $t
   and .account.remaining_bytes >= $t
+  and (.month.uploads_limit - .month.uploads_used) >= $n
   and .rate.uploads_hour_remaining >= $n
   and .rate.uploads_day_remaining >= $n' >/dev/null || {
     echo "batch of $n would exceed a cap; see aispace quota"; exit 4; }
 ```
 
-The monthly cap cannot be pre-checked, so a batch that clears this check can still stop partway
-with `429 monthly_upload_cap`. Treat that as terminal for the month rather than retrying, and
-report how many of the N uploads completed.
+Concurrent users can consume capacity after the pre-check, so a batch may still stop partway with
+`429 monthly_upload_cap`. Treat that as terminal for the month rather than retrying, and report how
+many of the N uploads completed.
 
 If the batch does not fit, prefer **one archive over many files** (`tar czf - dir | aispace upload
 - --name out.tgz`): it costs a single upload against the monthly cap instead of N. That is usually
@@ -293,7 +296,7 @@ What to tell the user for each failing term:
 | `limits.max_file_bytes < need` | File is over the per-file cap (5 MB on Free, 100 MB on Pro). Split it, compress it, or ask the human to upgrade. |
 | `key.remaining_bytes < need` | This key's budget is full. Delete old files (`aispace ls`, `aispace rm`) or ask the human to raise the budget in the dashboard. |
 | `account.remaining_bytes < need` | The account is at its storage allowance (10 MB on Free, 10 GB per Pro block). The human can free space or add a block. |
-| `429 monthly_upload_cap` (not pre-checkable) | The account's monthly upload cap is used up (100 on Free, 10,000 per Pro block). Nothing will upload until the next UTC month; tell the human to upgrade or mail contacts@aispace.sh. |
+| `.month.uploads_used >= .month.uploads_limit` or `429 monthly_upload_cap` | The account's monthly upload cap is used up. Nothing will upload until `.month.period_end`; tell the human to upgrade or mail contacts@aispace.sh. |
 | `rate.uploads_hour_remaining == 0` | Rate limited; wait until the top of the hour or batch outputs into one archive. |
 
 Every `/v1` response also carries `X-Quota-Remaining` (bytes left on the key), so a client that

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -147,7 +147,7 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 		if err != nil {
 			return nil, networkError(err)
 		}
-		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		if resp.StatusCode == http.StatusOK {
 			return resp, nil
 		}
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
@@ -165,6 +165,9 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 			}
 			req = req.Clone(req.Context())
 			continue
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			return nil, unexpectedStatus(resp.StatusCode, http.StatusOK)
 		}
 		return nil, errorFromResponse(resp, body)
 	}
@@ -358,18 +361,32 @@ func do[T any](c *Client, req *http.Request, wantStatus int) (Result[T], error) 
 			return Result[T]{}, err
 		}
 	}
-	if resp.StatusCode != wantStatus && (resp.StatusCode < 200 || resp.StatusCode > 299) {
+	if resp.StatusCode != wantStatus {
+		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			return Result[T]{}, unexpectedStatus(resp.StatusCode, wantStatus)
+		}
 		return Result[T]{}, errorFromResponse(resp, body)
 	}
 	var out Result[T]
-	if wantStatus == http.StatusNoContent || len(bytes.TrimSpace(body)) == 0 {
+	if wantStatus == http.StatusNoContent {
 		return out, nil
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return Result[T]{}, &Error{Status: resp.StatusCode, Code: "bad_response", Message: "server returned an empty response body"}
 	}
 	out.Raw = json.RawMessage(bytes.TrimSpace(body))
 	if err := json.Unmarshal(body, &out.Value); err != nil {
 		return Result[T]{}, &Error{Status: resp.StatusCode, Code: "bad_response", Message: fmt.Sprintf("cannot decode response: %v", err), cause: err}
 	}
 	return out, nil
+}
+
+func unexpectedStatus(got, want int) *Error {
+	return &Error{
+		Status:  got,
+		Code:    "bad_response",
+		Message: fmt.Sprintf("server returned HTTP %d, expected HTTP %d", got, want),
+	}
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration, sleep func(time.Duration)) error {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -120,6 +120,7 @@ func TestErrorDecodingAndExitCodes(t *testing.T) {
 		{401, `{"error":{"code":"invalid_key","message":"Invalid key"}}`, "invalid_key", 3, "Invalid key"},
 		{401, ``, "unauthenticated", 3, "Unauthorized (HTTP 401)"},
 		{402, `{"error":{"code":"quota_exceeded","message":"Key budget exceeded","details":{"remaining":0}}}`, "quota_exceeded", 4, "Key budget exceeded"},
+		{400, `{"error":{"code":"file_too_large","message":"too big"}}`, "file_too_large", 4, "too big"},
 		{413, `{"error":{"code":"file_too_large","message":"too big"}}`, "file_too_large", 4, "too big"},
 		{429, `{"error":{"code":"rate_limited","message":"slow down"}}`, "rate_limited", 5, "slow down"},
 		{404, `{"error":{"code":"not_found","message":"nope"}}`, "not_found", 1, "nope"},
@@ -583,5 +584,40 @@ func TestBadJSONResponse(t *testing.T) {
 	var ae *Error
 	if !errors.As(err, &ae) || ae.Code != "bad_response" {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestSuccessfulObjectResponseRequiresExpectedStatusAndBody(t *testing.T) {
+	t.Run("unexpected 2xx status", func(t *testing.T) {
+		c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+		_, err := c.Quota(context.Background())
+		var ae *Error
+		if !errors.As(err, &ae) || ae.Code != "bad_response" || ae.Status != http.StatusNoContent {
+			t.Fatalf("err = %#v", err)
+		}
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		_, err := c.Quota(context.Background())
+		var ae *Error
+		if !errors.As(err, &ae) || ae.Code != "bad_response" || !strings.Contains(ae.Message, "empty") {
+			t.Fatalf("err = %#v", err)
+		}
+	})
+}
+
+func TestDownloadRequiresHTTP200(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	_, err := c.Download(context.Background(), "01A")
+	var ae *Error
+	if !errors.As(err, &ae) || ae.Code != "bad_response" || ae.Status != http.StatusNoContent {
+		t.Fatalf("err = %#v", err)
 	}
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -21,9 +21,17 @@ func (e *Error) Error() string { return e.Message }
 // Unwrap exposes the transport cause, if any.
 func (e *Error) Unwrap() error { return e.cause }
 
-// ExitCode maps the error to the CLI exit code contract:
-// 3 auth (401), 4 quota (402/413), 5 rate limited (429), 1 otherwise.
+// ExitCode maps stable API codes first, then falls back to HTTP status for
+// compatible servers that did not return a structured error.
 func (e *Error) ExitCode() int {
+	switch e.Code {
+	case "invalid_key", "key_revoked", "unauthenticated":
+		return 3
+	case "quota_exceeded", "allowance_exceeded", "payment_required", "file_too_large":
+		return 4
+	case "rate_limited", "monthly_upload_cap", "monthly_download_cap":
+		return 5
+	}
 	switch e.Status {
 	case http.StatusUnauthorized:
 		return 3

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -62,6 +62,13 @@ type Quota struct {
 		Plan           string `json:"plan"`
 		ExtraBlocks    int64  `json:"extra_blocks"`
 	} `json:"account"`
+	Month struct {
+		UploadsUsed    int64 `json:"uploads_used"`
+		UploadsLimit   int64 `json:"uploads_limit"`
+		DownloadsUsed  int64 `json:"downloads_used"`
+		DownloadsLimit int64 `json:"downloads_limit"`
+		PeriodEnd      int64 `json:"period_end"`
+	} `json:"month"`
 	Limits struct {
 		MaxFileBytes      int64 `json:"max_file_bytes"`
 		MaxFileTTLSeconds int64 `json:"max_file_ttl_seconds"`


### PR DESCRIPTION
## Summary
- classify stable API error codes before HTTP-status fallbacks
- model and display account-wide monthly quota counters
- reject unexpected 2xx statuses and empty object responses
- align checksum and expiry documentation with the shipped server

## Verification
- go test ./...
- go vet ./...
- go test -race ./...