### PR TITLE
fix: preserve generated identities after uncertain uploads

### DIFF
--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -32,7 +32,9 @@ type encryptedUpload struct {
 	Identity     string
 	IdentityFile string
 	OriginalName string
-	cleanup      func()
+	recoveryFile string
+	identityPath string
+	cleanupBody  func()
 }
 
 type encryptionOutput struct {
@@ -112,45 +114,62 @@ func encryptForUpload(src io.Reader, originalName, recipientText, identityOut st
 		identity = generated.String()
 	}
 
+	identityPath := identityOut
+	recoveryFile := ""
 	if identityOut != "" {
 		if err := writeSecretFile(identityOut, identity+"\n"); err != nil {
 			return nil, err
 		}
+	} else if identity != "" {
+		var err error
+		recoveryFile, err = writeRecoveryIdentity(identity + "\n")
+		if err != nil {
+			return nil, err
+		}
+		identityPath = recoveryFile
 	}
+	cleanupIdentity := func() { _ = os.Remove(identityPath) }
 
 	tmp, err := os.CreateTemp("", "aispace-encrypted-*.age")
 	if err != nil {
+		cleanupIdentity()
 		return nil, &codedError{code: "io", err: fmt.Errorf("create encryption temp file: %w", err), exit: ExitGeneric}
 	}
-	cleanup := func() {
+	cleanupBody := func() {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
 	}
 	if err := tmp.Chmod(0o600); err != nil {
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "io", err: fmt.Errorf("secure encryption temp file: %w", err), exit: ExitGeneric}
 	}
 	w, err := age.Encrypt(tmp, recipient)
 	if err != nil {
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "encryption", err: fmt.Errorf("start encryption: %w", err), exit: ExitGeneric}
 	}
 	if _, err := io.Copy(w, src); err != nil {
 		_ = w.Close()
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "io", err: fmt.Errorf("encrypt %s: %w", originalName, err), exit: ExitGeneric}
 	}
 	if err := w.Close(); err != nil {
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "encryption", err: fmt.Errorf("finish encryption: %w", err), exit: ExitGeneric}
 	}
 	st, err := tmp.Stat()
 	if err != nil {
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "io", err: fmt.Errorf("stat encrypted file: %w", err), exit: ExitGeneric}
 	}
 	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		cleanup()
+		cleanupBody()
+		cleanupIdentity()
 		return nil, &codedError{code: "io", err: fmt.Errorf("rewind encrypted file: %w", err), exit: ExitGeneric}
 	}
 	return &encryptedUpload{
@@ -160,8 +179,55 @@ func encryptForUpload(src io.Reader, originalName, recipientText, identityOut st
 		Identity:     identity,
 		IdentityFile: identityOut,
 		OriginalName: originalName,
-		cleanup:      cleanup,
+		recoveryFile: recoveryFile,
+		identityPath: identityPath,
+		cleanupBody:  cleanupBody,
 	}, nil
+}
+
+func writeRecoveryIdentity(value string) (string, error) {
+	f, err := os.CreateTemp("", "aispace-identity-recovery-*.agekey")
+	if err != nil {
+		return "", &codedError{code: "io", err: fmt.Errorf("create recovery identity file: %w", err), exit: ExitGeneric}
+	}
+	path := f.Name()
+	ok := false
+	defer func() {
+		_ = f.Close()
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if err := f.Chmod(0o600); err != nil {
+		return "", &codedError{code: "io", err: fmt.Errorf("secure recovery identity file: %w", err), exit: ExitGeneric}
+	}
+	if _, err := io.WriteString(f, value); err != nil {
+		return "", &codedError{code: "io", err: fmt.Errorf("write recovery identity file: %w", err), exit: ExitGeneric}
+	}
+	if err := f.Close(); err != nil {
+		return "", &codedError{code: "io", err: fmt.Errorf("close recovery identity file: %w", err), exit: ExitGeneric}
+	}
+	ok = true
+	return path, nil
+}
+
+func (e *encryptedUpload) cleanup() {
+	e.cleanupBody()
+	if e.identityPath != "" {
+		_ = os.Remove(e.identityPath)
+	}
+}
+
+func (e *encryptedUpload) preserveIdentity() string {
+	path := e.identityPath
+	e.identityPath = ""
+	return path
+}
+
+func (e *encryptedUpload) uploadConfirmed() {
+	if e.IdentityFile != "" {
+		e.preserveIdentity()
+	}
 }
 
 func writeSecretFile(path, value string) error {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -160,6 +160,9 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 		}
 		return err
 	}
+	if encrypted != nil {
+		encrypted.uploadConfirmed()
+	}
 	file := fileRes.Value
 
 	if !f.link {
@@ -221,17 +224,25 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 // even though no success response reached the client. Those identities are
 // kept, and the caller is told why.
 func (a *app) discardUnusedIdentity(e *encryptedUpload, err error) {
-	if e.IdentityFile == "" {
-		return
-	}
 	var ae *api.Error
 	if errors.As(err, &ae) && ae.Status >= 400 && ae.Status < 500 {
 		// The server rejected the request, so no ciphertext exists.
-		if os.Remove(e.IdentityFile) == nil {
+		if e.identityPath == "" || os.Remove(e.identityPath) == nil {
+			e.identityPath = ""
 			return
 		}
+		fmt.Fprintf(a.stderr, "warning: could not remove unused identity file %s\n", e.identityPath)
+		return
 	}
-	fmt.Fprintf(a.stderr, "warning: kept identity file %s; the upload may still have stored the file, so check `aispace ls` before removing it\n", e.IdentityFile)
+	path := e.preserveIdentity()
+	if path == "" {
+		return
+	}
+	label := "identity file"
+	if e.IdentityFile == "" {
+		label = "recovery identity file"
+	}
+	fmt.Fprintf(a.stderr, "warning: kept %s %s; the upload may still have stored the file, so check `aispace ls` before removing it\n", label, path)
 }
 
 func resolvedUploadName(path, nameFlag string) string {

--- a/cmd/upload_identity_test.go
+++ b/cmd/upload_identity_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -8,8 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	"filippo.io/age"
+
 	"github.com/aispace-sh/aispace-client/internal/config"
 )
+
+type failingUploadReader struct{}
+
+func (failingUploadReader) Read([]byte) (int, error) { return 0, errors.New("source failed") }
 
 func TestInvalidEncryptedUploadLeavesNoIdentity(t *testing.T) {
 	isolate(t)
@@ -98,6 +105,66 @@ func TestUploadKeepsIdentityWhenOutcomeIsUnknown(t *testing.T) {
 	}
 	if !strings.Contains(r.stderr, "kept identity file") {
 		t.Fatalf("stderr should explain why the file was kept: %q", r.stderr)
+	}
+}
+
+func TestUploadKeepsGeneratedRecoveryIdentityWhenOutcomeIsUnknown(t *testing.T) {
+	isolate(t)
+	f := newFakeServer(t)
+	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+	dir := t.TempDir()
+	src := filepath.Join(dir, "secret.pdf")
+	if err := os.WriteFile(src, []byte("confidential"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	f.srv.Close()
+	r := run("", "upload", src, "--encrypt")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	const prefix = "warning: kept recovery identity file "
+	start := strings.Index(r.stderr, prefix)
+	if start < 0 {
+		t.Fatalf("stderr should name a recovery identity: %q", r.stderr)
+	}
+	path := strings.SplitN(r.stderr[start+len(prefix):], ";", 2)[0]
+	t.Cleanup(func() { _ = os.Remove(path) })
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read recovery identity: %v", err)
+	}
+	if _, err := age.ParseX25519Identity(strings.TrimSpace(string(raw))); err != nil {
+		t.Fatalf("recovery file does not contain a usable identity: %v", err)
+	}
+}
+
+func TestGeneratedRecoveryIdentityIsTemporaryOnSuccess(t *testing.T) {
+	e, err := encryptForUpload(strings.NewReader("secret"), "secret.txt", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := e.recoveryFile
+	if path == "" {
+		t.Fatal("generated upload has no recovery identity")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("recovery identity was not created: %v", err)
+	}
+	e.cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("recovery identity survived cleanup: %v", err)
+	}
+}
+
+func TestLocalEncryptionFailureRemovesIdentityFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret.agekey")
+	_, err := encryptForUpload(failingUploadReader{}, "secret.txt", "", path)
+	if err == nil {
+		t.Fatal("expected encryption to fail")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("identity file survived local encryption failure: %v", err)
 	}
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -254,7 +254,9 @@ If the server *rejects* the upload (quota, size, rate limit, bad key), a file wr
 leaving it behind would make retrying the same command fail with `identity file already exists`.
 When the request fails without a response or returns a 5xx server error, the outcome is uncertain,
 so the identity is kept and a warning names it — check `aispace ls` before deleting it, because the
-file may have been stored.
+file may have been stored. When no `--identity-out` was supplied, the CLI creates a mode-`0600`
+temporary recovery identity before uploading. It removes that recovery copy after a definite
+success or rejection, but keeps it and prints its path after an uncertain outcome.
 
 ### `aispace download`
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -14,7 +14,9 @@ operational configuration are maintained separately.
 
 `aispace upload --encrypt` encrypts locally with age X25519 before upload. The service receives
 ciphertext, not plaintext or the private identity. Generated identity files use mode `0600` and
-are never overwritten.
+are never overwritten. When an identity would normally be printed after upload, the CLI holds a
+mode-`0600` temporary recovery copy until the server outcome is known. It retains and names that
+file only if a network or server failure leaves it uncertain whether ciphertext was stored.
 
 Treat `AGE-SECRET-KEY-...` identities as credentials. Never upload them with their ciphertext.
 Deliver the URL and identity through separate authenticated channels when practical. Encryption


### PR DESCRIPTION
## Summary
- create a mode-0600 recovery identity before generated-key uploads
- remove recovery material after definite success, rejection, or local failure
- retain and report the recovery path when a network or 5xx outcome is ambiguous
- clean up explicit identity files when encryption fails before upload

## Verification
- go test ./...
- go vet ./...
- go test -race ./...