### PR TITLE
fix: stop stalled transfers and honor cancellation

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -21,17 +21,48 @@ import (
 	"time"
 
 	"filippo.io/age"
+	"github.com/spf13/cobra"
 
 	"github.com/aispace-sh/aispace-client/internal/config"
 )
 
-func TestCancellationWinsOverWrappedLocalError(t *testing.T) {
-	a := &app{}
-	err := &codedError{code: "io", err: fmt.Errorf("read stdin: %w", context.Canceled), exit: ExitGeneric}
-	exit, code := a.classify(err)
+func TestCancellationClosesStdinAndWinsOverClosedFileError(t *testing.T) {
+	stdin := newBlockingReadCloser()
+	root := &cobra.Command{RunE: func(*cobra.Command, []string) error {
+		_, err := io.Copy(io.Discard, stdin)
+		return &codedError{code: "io", err: fmt.Errorf("read stdin: %w", err), exit: ExitGeneric}
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-stdin.reading
+		cancel()
+	}()
+	err := executeCommand(root, ctx, stdin, cancel)
+	exit, code := (&app{}).classify(err)
 	if exit != ExitGeneric || code != "interrupted" {
 		t.Fatalf("classify = (%d, %q), want (%d, interrupted)", exit, code, ExitGeneric)
 	}
+}
+
+type blockingReadCloser struct {
+	reading chan struct{}
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{reading: make(chan struct{}), closed: make(chan struct{})}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	r.once.Do(func() { close(r.reading) })
+	<-r.closed
+	return 0, os.ErrClosed
+}
+
+func (r *blockingReadCloser) Close() error {
+	close(r.closed)
+	return nil
 }
 
 // fakeServer is a minimal in-memory aispace /v1 implementation.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +24,15 @@ import (
 
 	"github.com/aispace-sh/aispace-client/internal/config"
 )
+
+func TestCancellationWinsOverWrappedLocalError(t *testing.T) {
+	a := &app{}
+	err := &codedError{code: "io", err: fmt.Errorf("read stdin: %w", context.Canceled), exit: ExitGeneric}
+	exit, code := a.classify(err)
+	if exit != ExitGeneric || code != "interrupted" {
+		t.Fatalf("classify = (%d, %q), want (%d, interrupted)", exit, code, ExitGeneric)
+	}
+}
 
 // fakeServer is a minimal in-memory aispace /v1 implementation.
 type fakeServer struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,9 +85,26 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer, version strin
 	root.SetErr(stderr)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	executionDone := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			// Restore default signal handling so a second interrupt terminates even
+			// if a local stdin read cannot return. Closing stdin unblocks normal pipes.
+			stop()
+			if closer, ok := stdin.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		case <-executionDone:
+		}
+	}()
 
 	err := root.ExecuteContext(ctx)
+	close(executionDone)
+	<-watcherDone
+	stop()
 	if err == nil {
 		return ExitOK
 	}
@@ -274,6 +291,9 @@ func validateKey(key string) error {
 
 // classify maps an error to (exit code, error code string).
 func (a *app) classify(err error) (int, string) {
+	if errors.Is(err, context.Canceled) {
+		return ExitGeneric, "interrupted"
+	}
 	var ue *usageError
 	if errors.As(err, &ue) {
 		return ExitUsage, "usage"
@@ -285,9 +305,6 @@ func (a *app) classify(err error) (int, string) {
 	var ae *api.Error
 	if errors.As(err, &ae) {
 		return ae.ExitCode(), ae.Code
-	}
-	if errors.Is(err, context.Canceled) {
-		return ExitGeneric, "interrupted"
 	}
 	return ExitGeneric, "error"
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,19 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer, version strin
 	root.SetErr(stderr)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	err := executeCommand(root, ctx, stdin, stop)
+	if err == nil {
+		return ExitOK
+	}
+	code, apiCode := a.classify(err)
+	var reported *reportedError
+	if !errors.As(err, &reported) {
+		a.printError(err, apiCode)
+	}
+	return code
+}
+
+func executeCommand(root *cobra.Command, ctx context.Context, stdin io.Reader, stop func()) error {
 	executionDone := make(chan struct{})
 	watcherDone := make(chan struct{})
 	go func() {
@@ -104,16 +117,12 @@ func Run(args []string, stdin io.Reader, stdout, stderr io.Writer, version strin
 	err := root.ExecuteContext(ctx)
 	close(executionDone)
 	<-watcherDone
+	interrupted := ctx.Err() != nil
 	stop()
-	if err == nil {
-		return ExitOK
+	if interrupted {
+		return context.Canceled
 	}
-	code, apiCode := a.classify(err)
-	var reported *reportedError
-	if !errors.As(err, &reported) {
-		a.printError(err, apiCode)
-	}
-	return code
+	return err
 }
 
 func (a *app) newRootCmd() *cobra.Command {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -119,9 +119,9 @@ retried automatically; the agent decides. `Retry-After` is echoed in the error m
 ## Timeouts
 
 There is **no deadline on a transfer as a whole**. A large file over a slow link is slow, not
-broken, and a single cap covering the response body would really be a bandwidth floor: at a
-ten-minute cap, a 100 MB upload has to sustain about 1.4 Mbit/s or fail after moving most of
-itself.
+broken. Instead, uploads and downloads have a two-minute inactivity timeout that resets whenever
+body bytes move. A transfer can run for hours while making progress, but a connected peer that
+stops moving data does not hold an unattended process forever.
 
 What is bounded are the phases before any bytes flow, so an unreachable or silent server is still
 given up on quickly:
@@ -131,9 +131,11 @@ given up on quickly:
 | TCP connect | 30s |
 | TLS handshake | 10s |
 | Waiting for response headers | 60s |
+| Upload/download with no byte progress | 2m |
 
-A stalled transfer is therefore ended by the peer or by the operator, not by a timer:
-`Ctrl-C`/`SIGTERM` cancels in-flight requests and exits `1` with code `interrupted`.
+`Ctrl-C`/`SIGTERM` cancels in-flight requests, closes stdin to unblock ordinary pipes, and exits `1`
+with code `interrupted`. After the first signal, default handling is restored so a second interrupt
+can terminate a source that cannot be closed cleanly.
 
 ## Durations
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -139,7 +139,7 @@ func (c *Client) Upload(ctx context.Context, body io.Reader, opts UploadOptions)
 	if opts.Visibility != "" {
 		req.Header.Set("X-File-Visibility", opts.Visibility)
 	}
-	res, err := do[File](c, req, http.StatusCreated)
+	res, err := doRequest[File](c, req, http.StatusCreated, watch)
 	if errors.Is(context.Cause(transferCtx), ErrTransferStalled) {
 		return Result[File]{}, stalledError()
 	}
@@ -170,6 +170,7 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 		}
 		if resp.StatusCode == http.StatusOK {
 			if watch != nil {
+				watch.touch()
 				resp.Body = &watchedBody{ReadCloser: resp.Body, ctx: transferCtx, watch: watch}
 			}
 			return resp, nil
@@ -373,11 +374,15 @@ func (c *Client) newRequest(ctx context.Context, method, path string, body io.Re
 
 // do executes the request, retrying GET requests once on temporary rate limits.
 func do[T any](c *Client, req *http.Request, wantStatus int) (Result[T], error) {
+	return doRequest[T](c, req, wantStatus, nil)
+}
+
+func doRequest[T any](c *Client, req *http.Request, wantStatus int, watch *transferWatch) (Result[T], error) {
 	httpc := c.HTTP
 	if httpc == nil {
 		httpc = http.DefaultClient
 	}
-	resp, body, err := send(httpc, req)
+	resp, body, err := send(httpc, req, watch)
 	if err != nil {
 		return Result[T]{}, err
 	}
@@ -387,7 +392,7 @@ func do[T any](c *Client, req *http.Request, wantStatus int) (Result[T], error) 
 			return Result[T]{}, err
 		}
 		retry := req.Clone(req.Context())
-		resp, body, err = send(httpc, retry)
+		resp, body, err = send(httpc, retry, watch)
 		if err != nil {
 			return Result[T]{}, err
 		}
@@ -444,10 +449,14 @@ func waitForRetry(ctx context.Context, delay time.Duration, sleep func(time.Dura
 	}
 }
 
-func send(httpc *http.Client, req *http.Request) (*http.Response, []byte, error) {
+func send(httpc *http.Client, req *http.Request, watch *transferWatch) (*http.Response, []byte, error) {
 	resp, err := httpc.Do(req)
 	if err != nil {
 		return nil, nil, networkError(err)
+	}
+	if watch != nil {
+		watch.touch()
+		resp.Body = &watchedBody{ReadCloser: resp.Body, ctx: req.Context(), watch: watch}
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -32,6 +32,9 @@ const (
 	// HeaderTimeout bounds the wait for response headers, which is what catches
 	// a server that accepts the connection and then goes quiet.
 	HeaderTimeout = 60 * time.Second
+	// TransferInactivityTimeout cancels an upload or download when no body bytes
+	// move for this long. It resets whenever progress is made.
+	TransferInactivityTimeout = 2 * time.Minute
 )
 
 // NewHTTPClient returns the HTTP client used for aispace requests: quick to
@@ -67,6 +70,8 @@ type Client struct {
 	Key       string
 	UserAgent string
 	HTTP      *http.Client
+	// InactivityTimeout bounds time without byte progress during transfers. Zero disables it.
+	InactivityTimeout time.Duration
 	// Sleep overrides retry waiting for tests. Nil uses a context-aware timer.
 	Sleep func(time.Duration)
 }
@@ -74,10 +79,11 @@ type Client struct {
 // New returns a Client with sane defaults. baseURL must include the scheme.
 func New(baseURL, key, userAgent string) *Client {
 	return &Client{
-		BaseURL:   strings.TrimRight(baseURL, "/"),
-		Key:       key,
-		UserAgent: userAgent,
-		HTTP:      NewHTTPClient(),
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		Key:               key,
+		UserAgent:         userAgent,
+		HTTP:              NewHTTPClient(),
+		InactivityTimeout: TransferInactivityTimeout,
 	}
 }
 
@@ -99,7 +105,12 @@ type UploadOptions struct {
 
 // Upload streams body to POST /v1/files.
 func (c *Client) Upload(ctx context.Context, body io.Reader, opts UploadOptions) (Result[File], error) {
-	req, err := c.newRequest(ctx, http.MethodPost, "/v1/files", body)
+	transferCtx, watch := startTransferWatch(ctx, c.InactivityTimeout)
+	defer watch.stop()
+	if watch != nil {
+		body = &progressReader{r: body, watch: watch}
+	}
+	req, err := c.newRequest(transferCtx, http.MethodPost, "/v1/files", body)
 	if err != nil {
 		return Result[File]{}, err
 	}
@@ -128,14 +139,20 @@ func (c *Client) Upload(ctx context.Context, body io.Reader, opts UploadOptions)
 	if opts.Visibility != "" {
 		req.Header.Set("X-File-Visibility", opts.Visibility)
 	}
-	return do[File](c, req, http.StatusCreated)
+	res, err := do[File](c, req, http.StatusCreated)
+	if errors.Is(context.Cause(transferCtx), ErrTransferStalled) {
+		return Result[File]{}, stalledError()
+	}
+	return res, err
 }
 
 // Download opens an authenticated stream from GET /v1/files/:id/content.
 // The caller must close the response body.
 func (c *Client) Download(ctx context.Context, id string) (*http.Response, error) {
-	req, err := c.newRequest(ctx, http.MethodGet, "/v1/files/"+url.PathEscape(id)+"/content", nil)
+	transferCtx, watch := startTransferWatch(ctx, c.InactivityTimeout)
+	req, err := c.newRequest(transferCtx, http.MethodGet, "/v1/files/"+url.PathEscape(id)+"/content", nil)
 	if err != nil {
+		watch.stop()
 		return nil, err
 	}
 	httpc := c.HTTP
@@ -145,14 +162,25 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 	for attempt := 0; ; attempt++ {
 		resp, err := httpc.Do(req)
 		if err != nil {
+			watch.stop()
+			if errors.Is(context.Cause(transferCtx), ErrTransferStalled) {
+				return nil, stalledError()
+			}
 			return nil, networkError(err)
 		}
 		if resp.StatusCode == http.StatusOK {
+			if watch != nil {
+				resp.Body = &watchedBody{ReadCloser: resp.Body, ctx: transferCtx, watch: watch}
+			}
 			return resp, nil
 		}
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 		_ = resp.Body.Close()
 		if readErr != nil {
+			watch.stop()
+			if errors.Is(context.Cause(transferCtx), ErrTransferStalled) {
+				return nil, stalledError()
+			}
 			return nil, &Error{Code: "network", Message: "reading response: " + readErr.Error(), cause: readErr}
 		}
 		// Authenticated downloads consume monthly allowance. A gateway error may
@@ -161,14 +189,17 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 		// download handler and remains safe to retry.
 		if attempt == 0 && retryableRateLimit(resp, body) {
 			if err := waitForRetry(req.Context(), retryDelay(resp.Header.Get("Retry-After")), c.Sleep); err != nil {
+				watch.stop()
 				return nil, err
 			}
 			req = req.Clone(req.Context())
 			continue
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			watch.stop()
 			return nil, unexpectedStatus(resp.StatusCode, http.StatusOK)
 		}
+		watch.stop()
 		return nil, errorFromResponse(resp, body)
 	}
 }

--- a/internal/api/timeout_test.go
+++ b/internal/api/timeout_test.go
@@ -185,3 +185,48 @@ func TestStalledUploadResponseBodyTimesOut(t *testing.T) {
 		t.Fatalf("error = %v, want ErrTransferStalled", err)
 	}
 }
+
+func TestUploadWatchStartsWhenBodyTransferStarts(t *testing.T) {
+	c := New("https://example.test", "ask_test", "test")
+	c.InactivityTimeout = 25 * time.Millisecond
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		time.Sleep(60 * time.Millisecond)
+		if _, err := io.ReadAll(req.Body); err != nil {
+			return nil, err
+		}
+		body := `{"id":"01FILE","name":"payload","content_type":"application/octet-stream","size_bytes":7,"visibility":"private","created_at":1,"expires_at":2}`
+		return &http.Response{StatusCode: http.StatusCreated, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+
+	res, err := c.Upload(context.Background(), strings.NewReader("payload"), UploadOptions{Size: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Value.ID != "01FILE" {
+		t.Fatalf("file ID = %q, want 01FILE", res.Value.ID)
+	}
+}
+
+func TestCompletedTransferCannotBecomeStalledLater(t *testing.T) {
+	ctx, watch := startTransferWatch(context.Background(), 20*time.Millisecond)
+	body := &watchedBody{
+		ReadCloser: io.NopCloser(strings.NewReader("complete")),
+		ctx:        ctx,
+		watch:      watch,
+	}
+	watch.touch()
+	if _, err := io.ReadAll(body); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if cause := context.Cause(ctx); cause != nil {
+		t.Fatalf("completed transfer cause = %v, want nil", cause)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/api/timeout_test.go
+++ b/internal/api/timeout_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -121,5 +123,65 @@ func TestNewUsesTheSharedClient(t *testing.T) {
 	c := New("https://example.test", "ask_x", "ua")
 	if c.HTTP == nil || c.HTTP.Timeout != 0 {
 		t.Fatalf("client HTTP = %+v, want the shared no-total-deadline client", c.HTTP)
+	}
+	if c.InactivityTimeout != TransferInactivityTimeout {
+		t.Fatalf("inactivity timeout = %v, want %v", c.InactivityTimeout, TransferInactivityTimeout)
+	}
+}
+
+func TestSlowProgressResetsDownloadInactivityTimeout(t *testing.T) {
+	srv := trickle(t, 6, 40*time.Millisecond)
+	c := New(srv.URL, "ask_test", "test")
+	c.InactivityTimeout = 70 * time.Millisecond
+
+	resp, err := c.Download(context.Background(), "file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if body, err := io.ReadAll(resp.Body); err != nil || len(body) != 30 {
+		t.Fatalf("body length = %d, err = %v", len(body), err)
+	}
+}
+
+func TestStalledDownloadBodyTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "ask_test", "test")
+	c.InactivityTimeout = 50 * time.Millisecond
+
+	resp, err := c.Download(context.Background(), "file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	if !errors.Is(err, ErrTransferStalled) {
+		t.Fatalf("error = %v, want ErrTransferStalled", err)
+	}
+}
+
+func TestStalledUploadResponseBodyTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "ask_test", "test")
+	c.InactivityTimeout = 50 * time.Millisecond
+
+	_, err := c.Upload(context.Background(), strings.NewReader("payload"), UploadOptions{Size: 7})
+	if !errors.Is(err, ErrTransferStalled) {
+		t.Fatalf("error = %v, want ErrTransferStalled", err)
 	}
 }

--- a/internal/api/transfer.go
+++ b/internal/api/transfer.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"time"
+)
+
+// ErrTransferStalled means an upload or download made no byte progress before
+// the inactivity timer expired.
+var ErrTransferStalled = errors.New("transfer stalled")
+
+type transferWatch struct {
+	mu      sync.Mutex
+	timeout time.Duration
+	timer   *time.Timer
+	cancel  context.CancelCauseFunc
+	stopped bool
+}
+
+func startTransferWatch(parent context.Context, timeout time.Duration) (context.Context, *transferWatch) {
+	if timeout <= 0 {
+		return parent, nil
+	}
+	ctx, cancel := context.WithCancelCause(parent)
+	w := &transferWatch{timeout: timeout, cancel: cancel}
+	w.timer = time.AfterFunc(timeout, func() { cancel(ErrTransferStalled) })
+	return ctx, w
+}
+
+func (w *transferWatch) touch() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.timer.Reset(w.timeout)
+	}
+}
+
+func (w *transferWatch) stop() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	if !w.stopped {
+		w.stopped = true
+		w.timer.Stop()
+		w.cancel(nil)
+	}
+	w.mu.Unlock()
+}
+
+type progressReader struct {
+	r     io.Reader
+	watch *transferWatch
+}
+
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if n > 0 {
+		r.watch.touch()
+	}
+	return n, err
+}
+
+type watchedBody struct {
+	io.ReadCloser
+	ctx   context.Context
+	watch *transferWatch
+}
+
+func (b *watchedBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if n > 0 {
+		b.watch.touch()
+	}
+	if err != nil && errors.Is(context.Cause(b.ctx), ErrTransferStalled) {
+		return n, ErrTransferStalled
+	}
+	return n, err
+}
+
+func (b *watchedBody) Close() error {
+	b.watch.stop()
+	return b.ReadCloser.Close()
+}
+
+func stalledError() *Error {
+	return &Error{Code: "timeout", Message: "transfer stalled without byte progress", cause: ErrTransferStalled}
+}

--- a/internal/api/transfer.go
+++ b/internal/api/transfer.go
@@ -17,6 +17,7 @@ type transferWatch struct {
 	timeout time.Duration
 	timer   *time.Timer
 	cancel  context.CancelCauseFunc
+	active  bool
 	stopped bool
 }
 
@@ -26,7 +27,6 @@ func startTransferWatch(parent context.Context, timeout time.Duration) (context.
 	}
 	ctx, cancel := context.WithCancelCause(parent)
 	w := &transferWatch{timeout: timeout, cancel: cancel}
-	w.timer = time.AfterFunc(timeout, func() { cancel(ErrTransferStalled) })
 	return ctx, w
 }
 
@@ -36,8 +36,36 @@ func (w *transferWatch) touch() {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if !w.stopped {
+	if w.stopped {
+		return
+	}
+	w.active = true
+	if w.timer == nil {
+		w.timer = time.AfterFunc(w.timeout, w.expire)
+	} else {
+		w.timer.Stop()
 		w.timer.Reset(w.timeout)
+	}
+}
+
+func (w *transferWatch) pause() {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	w.active = false
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+	w.mu.Unlock()
+}
+
+func (w *transferWatch) expire() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped && w.active {
+		w.active = false
+		w.cancel(ErrTransferStalled)
 	}
 }
 
@@ -48,7 +76,10 @@ func (w *transferWatch) stop() {
 	w.mu.Lock()
 	if !w.stopped {
 		w.stopped = true
-		w.timer.Stop()
+		w.active = false
+		if w.timer != nil {
+			w.timer.Stop()
+		}
 		w.cancel(nil)
 	}
 	w.mu.Unlock()
@@ -64,6 +95,9 @@ func (r *progressReader) Read(p []byte) (int, error) {
 	if n > 0 {
 		r.watch.touch()
 	}
+	if err != nil {
+		r.watch.pause()
+	}
 	return n, err
 }
 
@@ -78,8 +112,11 @@ func (b *watchedBody) Read(p []byte) (int, error) {
 	if n > 0 {
 		b.watch.touch()
 	}
-	if err != nil && errors.Is(context.Cause(b.ctx), ErrTransferStalled) {
-		return n, ErrTransferStalled
+	if err != nil {
+		b.watch.pause()
+		if errors.Is(context.Cause(b.ctx), ErrTransferStalled) {
+			return n, ErrTransferStalled
+		}
 	}
 	return n, err
 }


### PR DESCRIPTION
## Summary
- add a two-minute inactivity watchdog that resets on upload/download byte progress
- keep transfers unlimited in total duration while ending dead connections
- classify wrapped cancellation consistently as interrupted
- close stdin on the first process signal and restore default handling for a second interrupt

## Verification
- go test ./internal/api ./cmd
- go vet ./...
- go test -race ./...