### PR TITLE
fix: harden npm binary installation

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -5,6 +5,10 @@ Linux, or Windows and verifies it against the SHA-256 checksums published with t
 release. The CLI creates expiring and revocable file links, emits predictable JSON for automation,
 and can encrypt files locally with age X25519 before upload.
 
+Installer downloads are HTTPS-only and restricted to GitHub release hosts. The binary is streamed
+to a bounded same-directory temporary file, verified, and atomically renamed into place; stalled
+downloads and oversized responses fail without leaving a partial executable.
+
 ```sh
 npm install -g @aispace-sh/cli
 aispace login --key ask_...

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -7,6 +7,9 @@ const https = require('node:https');
 const path = require('node:path');
 
 const REPOSITORY = 'aispace-sh/aispace-client';
+const REQUEST_INACTIVITY_MS = 30_000;
+const MAX_CHECKSUM_BYTES = 1024 * 1024;
+const MAX_BINARY_BYTES = 256 * 1024 * 1024;
 
 function platformAsset(platform = process.platform, arch = process.arch) {
   const os = { darwin: 'darwin', linux: 'linux', win32: 'windows' }[platform];
@@ -20,13 +23,32 @@ function binaryName(platform = process.platform) {
   return platform === 'win32' ? 'aispace.exe' : 'aispace';
 }
 
-function download(url, redirects = 0) {
-  if (redirects > 5) return Promise.reject(new Error('too many redirects'));
+function validateDownloadURL(value) {
+  const url = value instanceof URL ? value : new URL(value);
+  const trustedHost = url.hostname === 'github.com' || url.hostname.endsWith('.githubusercontent.com');
+  if (url.protocol !== 'https:' || !trustedHost || url.username || url.password) {
+    throw new Error(`refusing untrusted download URL: ${url.origin}`);
+  }
+  return url;
+}
+
+function responseFor(url, redirects = 0) {
   return new Promise((resolve, reject) => {
-    https.get(url, { headers: { 'User-Agent': 'aispace-cli npm installer' } }, (response) => {
+    let parsed;
+    try {
+      parsed = validateDownloadURL(url);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    const request = https.get(parsed, { headers: { 'User-Agent': 'aispace-cli npm installer' } }, (response) => {
       if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
         response.resume();
-        download(new URL(response.headers.location, url), redirects + 1).then(resolve, reject);
+        if (redirects >= 5) {
+          reject(new Error('too many redirects'));
+          return;
+        }
+        responseFor(new URL(response.headers.location, parsed), redirects + 1).then(resolve, reject);
         return;
       }
       if (response.statusCode !== 200) {
@@ -34,12 +56,83 @@ function download(url, redirects = 0) {
         reject(new Error(`download failed with HTTP ${response.statusCode}`));
         return;
       }
-      const chunks = [];
-      response.on('data', (chunk) => chunks.push(chunk));
-      response.on('end', () => resolve(Buffer.concat(chunks)));
-      response.on('error', reject);
-    }).on('error', reject);
+      response.setTimeout(REQUEST_INACTIVITY_MS, () => response.destroy(new Error('download stalled')));
+      resolve(response);
+    });
+    request.setTimeout(REQUEST_INACTIVITY_MS, () => request.destroy(new Error('download stalled')));
+    request.on('error', reject);
   });
+}
+
+async function downloadBuffer(url, maxBytes = MAX_CHECKSUM_BYTES) {
+  const response = await responseFor(url);
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    response.on('data', (chunk) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        response.destroy(new Error(`download exceeds ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    response.on('end', () => resolve(Buffer.concat(chunks)));
+    response.on('error', reject);
+  });
+}
+
+async function downloadToFile(url, destination, maxBytes = MAX_BINARY_BYTES) {
+  const response = await responseFor(url);
+  return new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(destination, { flags: 'wx', mode: 0o755 });
+    const hash = crypto.createHash('sha256');
+    let total = 0;
+    let settled = false;
+    let digest;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      response.destroy();
+      output.destroy();
+      reject(error);
+    };
+    response.on('data', (chunk) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        fail(new Error(`download exceeds ${maxBytes} bytes`));
+        return;
+      }
+      hash.update(chunk);
+    });
+    response.on('error', fail);
+    output.on('error', fail);
+    output.on('finish', () => {
+      digest = hash.digest('hex');
+    });
+    output.on('close', () => {
+      if (settled) return;
+      settled = true;
+      resolve(digest);
+    });
+    response.pipe(output);
+  });
+}
+
+function temporaryPath(target) {
+  const suffix = crypto.randomBytes(8).toString('hex');
+  return path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.${suffix}.tmp`);
+}
+
+function installLocalBinary(source, target) {
+  const temp = temporaryPath(target);
+  try {
+    fs.copyFileSync(source, temp, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(temp, 0o755);
+    fs.renameSync(temp, target);
+  } finally {
+    fs.rmSync(temp, { force: true });
+  }
 }
 
 function expectedChecksum(checksums, asset) {
@@ -52,20 +145,21 @@ async function main() {
   const pkg = require('../package.json');
   const target = path.join(__dirname, '..', 'bin', binaryName());
   if (process.env.AISPACE_NPM_BINARY) {
-    fs.copyFileSync(process.env.AISPACE_NPM_BINARY, target);
-    fs.chmodSync(target, 0o755);
+    installLocalBinary(process.env.AISPACE_NPM_BINARY, target);
     return;
   }
-  const asset = platformAsset();
-  const base = `https://github.com/${REPOSITORY}/releases/download/v${pkg.version}`;
-  const [binary, checksumFile] = await Promise.all([
-    download(`${base}/${asset}`),
-    download(`${base}/checksums.txt`),
-  ]);
-  const actual = crypto.createHash('sha256').update(binary).digest('hex');
-  const expected = expectedChecksum(checksumFile.toString('utf8'), asset);
-  if (actual !== expected) throw new Error(`checksum mismatch for ${asset}`);
-  fs.writeFileSync(target, binary, { mode: 0o755 });
+  const temp = temporaryPath(target);
+  try {
+    const asset = platformAsset();
+    const base = `https://github.com/${REPOSITORY}/releases/download/v${pkg.version}`;
+    const checksumFile = await downloadBuffer(`${base}/checksums.txt`);
+    const expected = expectedChecksum(checksumFile.toString('utf8'), asset);
+    const actual = await downloadToFile(`${base}/${asset}`, temp);
+    if (actual !== expected) throw new Error(`checksum mismatch for ${asset}`);
+    fs.renameSync(temp, target);
+  } finally {
+    fs.rmSync(temp, { force: true });
+  }
 }
 
 if (require.main === module) {
@@ -75,4 +169,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { binaryName, expectedChecksum, platformAsset };
+module.exports = { binaryName, expectedChecksum, installLocalBinary, platformAsset, temporaryPath, validateDownloadURL };

--- a/npm/test/install.test.js
+++ b/npm/test/install.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
-const { binaryName, expectedChecksum, platformAsset } = require('../scripts/install');
+const { binaryName, expectedChecksum, installLocalBinary, platformAsset, temporaryPath, validateDownloadURL } = require('../scripts/install');
 
 test('maps supported platforms to release assets', () => {
   assert.equal(platformAsset('darwin', 'arm64'), 'aispace_darwin_arm64');
@@ -23,4 +26,33 @@ test('extracts only the checksum for the requested asset', () => {
   const hash = 'a'.repeat(64);
   assert.equal(expectedChecksum(`${'b'.repeat(64)}  other\n${hash}  aispace_linux_amd64\n`, 'aispace_linux_amd64'), hash);
   assert.throws(() => expectedChecksum('', 'aispace_linux_amd64'), /checksum missing/);
+});
+
+test('accepts only trusted HTTPS release download URLs', () => {
+  assert.equal(validateDownloadURL('https://github.com/aispace-sh/aispace-client/releases').hostname, 'github.com');
+  assert.equal(validateDownloadURL('https://release-assets.githubusercontent.com/object').hostname, 'release-assets.githubusercontent.com');
+  assert.throws(() => validateDownloadURL('http://github.com/file'), /untrusted download URL/);
+  assert.throws(() => validateDownloadURL('https://githubusercontent.com.evil.example/file'), /untrusted download URL/);
+  assert.throws(() => validateDownloadURL('https://example.com/file'), /untrusted download URL/);
+});
+
+test('creates installer temporary files beside the final binary', () => {
+  const target = path.join('/tmp', 'package', 'bin', 'aispace');
+  const temp = temporaryPath(target);
+  assert.equal(path.dirname(temp), path.dirname(target));
+  assert.match(path.basename(temp), /^\.aispace\.\d+\.[a-f0-9]{16}\.tmp$/);
+});
+
+test('atomically replaces a binary without leaving its temporary file', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aispace-npm-install-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const source = path.join(dir, 'source');
+  const target = path.join(dir, 'aispace');
+  fs.writeFileSync(source, 'new binary');
+  fs.writeFileSync(target, 'old binary');
+
+  installLocalBinary(source, target);
+
+  assert.equal(fs.readFileSync(target, 'utf8'), 'new binary');
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['aispace', 'source']);
 });


### PR DESCRIPTION
## Summary
- restrict installer downloads and redirects to trusted HTTPS GitHub hosts
- enforce inactivity and response-size bounds
- stream binaries while hashing instead of buffering them in memory
- verify into a same-directory temporary file and atomically rename it
- clean temporary files on every failure path

## Verification
- node --check npm/scripts/install.js
- npm test
- npm pack --dry-run