### PR TITLE
fix: make partial releases resumable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
         description: Release version without the v prefix (for example, 0.1.0)
         required: true
         type: string
+      resume:
+        description: Resume this version after a failed partial release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -23,6 +28,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
       sha: ${{ steps.release.outputs.sha }}
+      tag_exists: ${{ steps.release.outputs.tag_exists }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -31,6 +37,7 @@ jobs:
         id: release
         env:
           VERSION_INPUT: ${{ inputs.version }}
+          RESUME: ${{ inputs.resume }}
         run: |
           VERSION="${VERSION_INPUT#v}"
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -42,14 +49,25 @@ jobs:
             exit 1
           fi
           TAG="v$VERSION"
+          TAG_EXISTS=false
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "tag $TAG already exists" >&2
-            exit 1
+            if [ "$RESUME" != "true" ]; then
+              echo "tag $TAG already exists; select resume only to recover that exact release" >&2
+              exit 1
+            fi
+            TAG_SHA="$(git rev-list -n 1 "$TAG")"
+            HEAD_SHA="$(git rev-parse HEAD)"
+            if [ "$TAG_SHA" != "$HEAD_SHA" ]; then
+              echo "tag $TAG points to $TAG_SHA, not current main $HEAD_SHA" >&2
+              exit 1
+            fi
+            TAG_EXISTS=true
           fi
           {
             echo "version=$VERSION"
             echo "tag=$TAG"
             echo "sha=$(git rev-parse HEAD)"
+            echo "tag_exists=$TAG_EXISTS"
           } >> "$GITHUB_OUTPUT"
 
   credentials:
@@ -137,6 +155,7 @@ jobs:
           go-version: '1.26.6'
           cache-dependency-path: go.sum
       - name: Create release tag
+        if: needs.validate.outputs.tag_exists != 'true'
         env:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
@@ -144,7 +163,24 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "refs/tags/$TAG"
+      - name: Inspect previous release attempt
+        id: release_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          PUBLISH=true
+          DRAFT="$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null || echo missing)"
+          if [ "$DRAFT" = "true" ]; then
+            echo "removing incomplete draft release $TAG before retry"
+            gh release delete "$TAG" --yes
+          elif [ "$DRAFT" = "false" ]; then
+            echo "published release $TAG already exists; preserving its immutable assets"
+            PUBLISH=false
+          fi
+          echo "publish=$PUBLISH" >> "$GITHUB_OUTPUT"
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        if: steps.release_state.outputs.publish == 'true'
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -157,6 +193,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: gh release upload "$TAG" install.sh --clobber
+      - name: Verify release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          ASSETS="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+          for NAME in checksums.txt install.sh \
+            aispace_darwin_amd64 aispace_darwin_arm64 \
+            aispace_linux_amd64 aispace_linux_arm64 \
+            aispace_windows_amd64.exe aispace_windows_arm64.exe
+          do
+            grep -Fx "$NAME" <<<"$ASSETS" >/dev/null || { echo "release asset missing: $NAME" >&2; exit 1; }
+          done
+      - name: Verify Homebrew cask version
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          gh api repos/aispace-sh/homebrew-tap/contents/Casks/aispace.rb --jq .content \
+            | base64 --decode | grep -F "version \"$VERSION\"" >/dev/null
 
   npm:
     name: Publish npm package
@@ -179,7 +235,20 @@ jobs:
         env:
           VERSION: ${{ needs.validate.outputs.version }}
         run: npm version "$VERSION" --no-git-tag-version
+      - name: Check for an existing npm publication
+        id: npm_state
+        working-directory: npm
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          if npm view "@aispace-sh/cli@$VERSION" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "@aispace-sh/cli@$VERSION is already published; preserving it"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package
+        if: steps.npm_state.outputs.published != 'true'
         working-directory: npm
         run: npm publish --access public
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,10 +189,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
       - name: Attach installer
+        if: steps.release_state.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
-        run: gh release upload "$TAG" install.sh --clobber
+        run: gh release upload "$TAG" install.sh
       - name: Verify release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -213,6 +214,12 @@ jobs:
         run: |
           gh api repos/aispace-sh/homebrew-tap/contents/Casks/aispace.rb --jq .content \
             | base64 --decode | grep -F "version \"$VERSION\"" >/dev/null
+      - name: Publish verified GitHub release
+        if: steps.release_state.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false
 
   npm:
     name: Publish npm package

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,6 +75,9 @@ changelog:
       - "^ci:"
 
 release:
+  # Keep partially uploaded releases recoverable. The workflow publishes the
+  # draft only after every required asset and the Homebrew cask are verified.
+  draft: true
   github:
     owner: aispace-sh
     name: aispace-client

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,6 +26,17 @@ checksum-verified native binaries.
 4. Confirm the final verification job installs the published npm package and reports the requested
    version.
 
+### Resume a partial release
+
+If a run fails after creating its tag, rerun the workflow from the same `main` commit with the same
+version and select **Resume**. Resume mode refuses a tag that points anywhere else. It removes only
+an incomplete draft GitHub release, preserves an already-published release and npm version, and
+continues whichever publication steps are still safe. The workflow then verifies the native npm
+assets, installer, and Homebrew cask before testing installation again on Linux and Windows.
+
+Do not select Resume to rebuild or replace published artifacts. If the published GitHub assets or
+Homebrew cask fail verification, investigate the channel and publish a new patch version.
+
 The release job must finish before npm publication starts, because the npm postinstall script
 downloads the native binary and `checksums.txt` from that GitHub release. GoReleaser updates
 `Casks/aispace.rb` in the tap during the same release job.
@@ -49,5 +60,5 @@ npm install -g @aispace-sh/cli
 aispace version
 ```
 
-Never reuse or move a published tag. Publish a new patch version if any channel fails after an
-immutable npm version has been created.
+Never reuse or move a published tag. Resume may finish missing channels for the exact tagged commit,
+but it never replaces an immutable published release or npm version.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,9 @@ checksum-verified native binaries.
 1. Open **Actions → Release → Run workflow**.
 2. Select the `main` branch and enter a version without the `v` prefix, such as `0.1.0`.
 3. Start the workflow. It validates the version and credentials, runs the Go and npm test suites,
-   performs GoReleaser and npm publication dry runs, and only then creates the tag and publishes.
+   performs GoReleaser and npm publication dry runs, and only then creates the tag. GoReleaser
+   uploads into a draft; the workflow publishes it only after all required assets and the Homebrew
+   cask have been verified.
 4. Confirm the final verification job installs the published npm package and reports the requested
    version.
 
@@ -30,9 +32,9 @@ checksum-verified native binaries.
 
 If a run fails after creating its tag, rerun the workflow from the same `main` commit with the same
 version and select **Resume**. Resume mode refuses a tag that points anywhere else. It removes only
-an incomplete draft GitHub release, preserves an already-published release and npm version, and
-continues whichever publication steps are still safe. The workflow then verifies the native npm
-assets, installer, and Homebrew cask before testing installation again on Linux and Windows.
+an incomplete draft GitHub release, rebuilds that draft, and preserves an already-published release
+and npm version. The workflow verifies the native npm assets, installer, and Homebrew cask before
+publishing the draft and testing installation again on Linux and Windows.
 
 Do not select Resume to rebuild or replace published artifacts. If the published GitHub assets or
 Homebrew cask fail verification, investigate the channel and publish a new patch version.


### PR DESCRIPTION
## Summary
- add an explicit resume mode restricted to an existing tag on the current main commit
- remove only incomplete draft releases before rerunning GoReleaser
- preserve already-published GitHub releases and npm versions
- verify required native assets, installer, and Homebrew cask before install tests
- document the safe recovery procedure

## Verification
- actionlint .github/workflows/release.yml
- Ruby YAML parse
- git diff --check