### PR TITLE
chore: validate documentation inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check shell scripts
         run: sh -n install.sh examples/*.sh
         if: runner.os == 'Linux'
+      - name: Validate documentation inventory
+        run: node scripts/validate-index-json.mjs .
+        if: runner.os == 'Linux'
       - name: Test npm wrapper
         working-directory: npm
         run: npm test && npm pack --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: sh -n install.sh examples/*.sh
         if: runner.os == 'Linux'
       - name: Validate documentation inventory
-        run: node scripts/validate-index-json.mjs .
+        run: node --test scripts/validate-index-json.test.mjs && node scripts/validate-index-json.mjs .
         if: runner.os == 'Linux'
       - name: Test npm wrapper
         working-directory: npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ go build -ldflags "-X main.version=0.0.0-dev" -o aispace .
 Tests that exercise the hosted service must use a dedicated low-budget key. Never commit a key or
 place it in a fixture, command transcript, issue, or pull-request description.
 
+Every `README.md` or document under `docs/` must be listed in `docs/index.json`, which groups pages
+for documentation consumers. Run `node scripts/validate-index-json.mjs .` after adding, moving, or
+removing a document; CI rejects missing, duplicate, orphaned, or dead entries.
+
 ## Pull requests
 
 Keep each pull request focused on one behavior. Add or update tests for behavior changes and update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,10 @@ go build -ldflags "-X main.version=0.0.0-dev" -o aispace .
 Tests that exercise the hosted service must use a dedicated low-budget key. Never commit a key or
 place it in a fixture, command transcript, issue, or pull-request description.
 
-Every `README.md` or document under `docs/` must be listed in `docs/index.json`, which groups pages
-for documentation consumers. Run `node scripts/validate-index-json.mjs .` after adding, moving, or
-removing a document; CI rejects missing, duplicate, orphaned, or dead entries.
+Every `README.md` or Markdown document under `docs/` must be listed in `docs/index.json`, which
+groups pages for documentation consumers. JSON files are treated as metadata unless explicitly
+listed as API-reference documents. Run `node scripts/validate-index-json.mjs .` after adding,
+moving, or removing a document; CI rejects missing, duplicate, orphaned, or dead entries.
 
 ## Pull requests
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -1,0 +1,15 @@
+{
+  "main": [
+    "README.md",
+    "LAUNCH.md",
+    "GOOD_FIRST_ISSUES.md"
+  ],
+  "guides": [
+    "LLM_USAGE.md",
+    "SECURITY.md"
+  ],
+  "reference": [
+    "CLI.md",
+    "API.md"
+  ]
+}

--- a/scripts/validate-index-json.mjs
+++ b/scripts/validate-index-json.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const supported = new Set(['.md', '.markdown', '.mdx', '.json']);
+const markdown = new Set(['.md', '.markdown', '.mdx']);
 const knownSections = new Set(['main', 'guides', 'architecture', 'reference']);
 const repoRoot = path.resolve(process.argv[2] || '.');
 const docsRoot = path.join(repoRoot, 'docs');
@@ -15,13 +16,17 @@ function isSupported(file) {
   return supported.has(path.extname(file).toLowerCase());
 }
 
-function walk(dir, base = '') {
+function isMarkdown(file) {
+  return markdown.has(path.extname(file).toLowerCase());
+}
+
+function walk(dir, base = '', include = isSupported) {
   const files = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.name.startsWith('.')) continue;
     const relative = base ? `${base}/${entry.name}` : entry.name;
-    if (entry.isDirectory()) files.push(...walk(path.join(dir, entry.name), relative));
-    if (entry.isFile() && isSupported(entry.name) && entry.name !== 'index.json') files.push(relative);
+    if (entry.isDirectory()) files.push(...walk(path.join(dir, entry.name), relative, include));
+    if (entry.isFile() && include(entry.name) && entry.name !== 'index.json') files.push(relative);
   }
   return files;
 }
@@ -31,6 +36,11 @@ function resolveSource(source) {
     if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
   }
   return null;
+}
+
+function normalizeSource(source) {
+  const relative = source.replace(/^\.\//, '');
+  return relative.startsWith('docs/') ? relative.slice('docs/'.length) : relative;
 }
 
 function expandWildcard(section, source) {
@@ -63,6 +73,12 @@ if (!index || typeof index !== 'object' || Array.isArray(index)) {
 }
 
 const reachable = new Set();
+function addReachable(source) {
+  const normalized = normalizeSource(source);
+  if (reachable.has(normalized)) errors.push(`duplicate entry: ${normalized}`);
+  else reachable.add(normalized);
+}
+
 for (const [section, rawEntries] of Object.entries(index)) {
   if (!knownSections.has(section)) warnings.push(`unknown section ${section}`);
   const entries = Array.isArray(rawEntries) ? rawEntries : [rawEntries];
@@ -72,18 +88,18 @@ for (const [section, rawEntries] of Object.entries(index)) {
   }
   for (const source of entries) {
     if (/^https?:\/\//i.test(source)) continue;
-    if (source === '*' || source.endsWith('/*')) {
-      for (const file of expandWildcard(section, source)) reachable.add(file);
+    const normalized = normalizeSource(source);
+    if (normalized === '*' || normalized.endsWith('/*')) {
+      for (const file of expandWildcard(section, normalized)) addReachable(file);
       continue;
     }
-    if (!isSupported(source)) errors.push(`${source} has an unsupported extension`);
-    if (!resolveSource(source)) errors.push(`dead entry: ${source}`);
-    else if (reachable.has(source)) errors.push(`duplicate entry: ${source}`);
-    else reachable.add(source);
+    if (!isSupported(normalized)) errors.push(`${source} has an unsupported extension`);
+    if (!resolveSource(normalized)) errors.push(`dead entry: ${source}`);
+    else addReachable(normalized);
   }
 }
 
-const onDisk = new Set(walk(docsRoot));
+const onDisk = new Set(walk(docsRoot, '', isMarkdown));
 if (fs.existsSync(path.join(repoRoot, 'README.md'))) onDisk.add('README.md');
 for (const orphan of [...onDisk].filter((file) => !reachable.has(file)).sort()) {
   errors.push(`orphan document: ${orphan}`);

--- a/scripts/validate-index-json.mjs
+++ b/scripts/validate-index-json.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const supported = new Set(['.md', '.markdown', '.mdx', '.json']);
+const knownSections = new Set(['main', 'guides', 'architecture', 'reference']);
+const repoRoot = path.resolve(process.argv[2] || '.');
+const docsRoot = path.join(repoRoot, 'docs');
+const indexPath = path.join(docsRoot, 'index.json');
+const errors = [];
+const warnings = [];
+
+function isSupported(file) {
+  return supported.has(path.extname(file).toLowerCase());
+}
+
+function walk(dir, base = '') {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const relative = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) files.push(...walk(path.join(dir, entry.name), relative));
+    if (entry.isFile() && isSupported(entry.name) && entry.name !== 'index.json') files.push(relative);
+  }
+  return files;
+}
+
+function resolveSource(source) {
+  for (const candidate of [path.join(docsRoot, source), path.join(repoRoot, source)]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+function expandWildcard(section, source) {
+  const folder = source === '*' ? section : source.slice(0, -2);
+  const absolute = path.join(docsRoot, folder);
+  if (!fs.existsSync(absolute) || !fs.statSync(absolute).isDirectory()) {
+    errors.push(`wildcard ${source} in ${section} points to missing docs/${folder}`);
+    return [];
+  }
+  const files = walk(absolute, folder);
+  if (files.length === 0) errors.push(`wildcard ${source} in ${section} is empty`);
+  return files;
+}
+
+if (!fs.existsSync(indexPath)) {
+  console.error(`missing ${indexPath}`);
+  process.exit(1);
+}
+
+let index;
+try {
+  index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+} catch (error) {
+  console.error(`invalid ${indexPath}: ${error.message}`);
+  process.exit(1);
+}
+if (!index || typeof index !== 'object' || Array.isArray(index)) {
+  console.error('docs/index.json must be an object');
+  process.exit(1);
+}
+
+const reachable = new Set();
+for (const [section, rawEntries] of Object.entries(index)) {
+  if (!knownSections.has(section)) warnings.push(`unknown section ${section}`);
+  const entries = Array.isArray(rawEntries) ? rawEntries : [rawEntries];
+  if (!entries.every((entry) => typeof entry === 'string')) {
+    errors.push(`section ${section} must contain a path or array of paths`);
+    continue;
+  }
+  for (const source of entries) {
+    if (/^https?:\/\//i.test(source)) continue;
+    if (source === '*' || source.endsWith('/*')) {
+      for (const file of expandWildcard(section, source)) reachable.add(file);
+      continue;
+    }
+    if (!isSupported(source)) errors.push(`${source} has an unsupported extension`);
+    if (!resolveSource(source)) errors.push(`dead entry: ${source}`);
+    else if (reachable.has(source)) errors.push(`duplicate entry: ${source}`);
+    else reachable.add(source);
+  }
+}
+
+const onDisk = new Set(walk(docsRoot));
+if (fs.existsSync(path.join(repoRoot, 'README.md'))) onDisk.add('README.md');
+for (const orphan of [...onDisk].filter((file) => !reachable.has(file)).sort()) {
+  errors.push(`orphan document: ${orphan}`);
+}
+
+console.log(`index.json: ${errors.length ? 'invalid' : 'valid'} — ${reachable.size} indexed / ${onDisk.size} on disk`);
+for (const warning of warnings) console.warn(`warning: ${warning}`);
+for (const error of errors) console.error(`error: ${error}`);
+process.exit(errors.length ? 1 : 0);

--- a/scripts/validate-index-json.test.mjs
+++ b/scripts/validate-index-json.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const validator = path.join(path.dirname(fileURLToPath(import.meta.url)), 'validate-index-json.mjs');
+
+function fixture(index, files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aispace-doc-index-'));
+  fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'docs', 'index.json'), JSON.stringify(index));
+  for (const [name, content] of Object.entries(files)) {
+    const target = path.join(root, name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return root;
+}
+
+function validate(root) {
+  return spawnSync(process.execPath, [validator, root], { encoding: 'utf8' });
+}
+
+test('normalizes entries prefixed with docs/', (t) => {
+  const root = fixture(
+    { main: ['README.md'], guides: ['docs/GUIDE.md'] },
+    { 'README.md': '# Main', 'docs/GUIDE.md': '# Guide' },
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = validate(root);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('does not treat JSON metadata as a document', (t) => {
+  const root = fixture({ main: ['README.md'] }, { 'README.md': '# Main', 'docs/search.json': '{}' });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = validate(root);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test('accepts an explicitly indexed JSON API reference', (t) => {
+  const root = fixture(
+    { main: ['README.md'], reference: ['reference/api.json'] },
+    { 'README.md': '# Main', 'docs/reference/api.json': '{}' },
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = validate(root);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const entries of [
+  ['guides/guide.md', 'guides/*'],
+  ['guides/*', 'guides/guide.md'],
+]) {
+  test(`detects overlapping entries in order: ${entries.join(', ')}`, (t) => {
+    const root = fixture(
+      { main: ['README.md'], guides: entries },
+      { 'README.md': '# Main', 'docs/guides/guide.md': '# Guide' },
+    );
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+    const result = validate(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /duplicate entry: guides\/guide\.md/);
+  });
+}


### PR DESCRIPTION
## Summary
- add docs/index.json with every repository document assigned to a supported role
- add a deterministic validator for schema, dead entries, duplicates, and orphan documents
- enforce the documentation inventory in Linux CI
- document the contributor workflow

## Verification
- node scripts/validate-index-json.mjs .
- docs-review reference validator
- actionlint .github/workflows/ci.yml
- JSON parse and git diff --check