### PR TITLE
feat(ls): --limit and --cursor to page a large account instead of always walking it

### DIFF
--- a/cmd/files.go
+++ b/cmd/files.go
@@ -190,33 +190,49 @@ func (a *app) linkCmd() *cobra.Command {
 
 func (a *app) lsCmd() *cobra.Command {
 	var all bool
+	var limit int
+	var cursor string
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List files uploaded with this key (all pages)",
-		Long:  "Lists every file for the key, following pagination. Human output is one line per file:\n<id> <size> <expires> <name>. With --json prints {\"files\": [...], \"next_cursor\": null} merged across pages.",
-		Args:  noArgs,
+		Use:   "ls [--limit N] [--cursor C]",
+		Short: "List files uploaded with this key",
+		Long: "Lists files for the key. By default it follows pagination to the end. Human output\n" +
+			"is one line per file: <id> <size> <expires> <name>.\n\n" +
+			"--limit stops after N files instead of walking the whole account, which costs\n" +
+			"fewer requests on a large one. When more files remain, --json reports the cursor\n" +
+			"to resume from in next_cursor; pass it back with --cursor to continue.",
+		Example: "  aispace ls --limit 50 --json\n" +
+			"  aispace ls --limit 50 --cursor \"$(aispace ls --limit 50 --json | jq -r .next_cursor)\" --json",
+		Args: noArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if limit < 0 {
+				return usagef("--limit must be >= 0")
+			}
 			c, err := a.client()
 			if err != nil {
 				return err
 			}
-			if a.jsonOut {
-				raws, _, err := c.ListAllFiles(cmd.Context())
+			if limit > 0 {
+				raws, files, next, err := c.ListPage(cmd.Context(), cursor, limit)
 				if err != nil {
 					return err
 				}
-				if raws == nil {
-					raws = []json.RawMessage{}
+				return a.printFileList(raws, files, next)
+			}
+			if a.jsonOut {
+				var raws []json.RawMessage
+				err := c.WalkFilesFrom(cmd.Context(), cursor, func(page []json.RawMessage, _ []api.File) error {
+					raws = append(raws, page...)
+					return nil
+				})
+				if err != nil {
+					return err
 				}
-				return a.printJSONValue(struct {
-					Files      []json.RawMessage `json:"files"`
-					NextCursor *string           `json:"next_cursor"`
-				}{Files: raws})
+				return a.printFileList(raws, nil, "")
 			}
 			count := 0
-			err = c.WalkFiles(cmd.Context(), func(_ []json.RawMessage, files []api.File) error {
+			err = c.WalkFilesFrom(cmd.Context(), cursor, func(_ []json.RawMessage, files []api.File) error {
 				for _, f := range files {
-					fmt.Fprintf(a.stdout, "%s %s %s %s\n", f.ID, fmtBytes(f.SizeBytes), fmtTime(f.ExpiresAt), f.Name)
+					a.printListLine(f)
 					count++
 				}
 				return nil
@@ -230,8 +246,44 @@ func (a *app) lsCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&all, "all", false, "accepted for compatibility; ls always follows pagination to the end")
+	cmd.Flags().BoolVar(&all, "all", false, "accepted for compatibility; ls follows pagination to the end unless --limit is given")
+	cmd.Flags().IntVar(&limit, "limit", 0, "stop after N files instead of listing the whole account")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "resume from a next_cursor returned by an earlier --limit run")
 	return cmd
+}
+
+// printFileList renders a listing in whichever mode is active. next is the
+// cursor to resume from, empty when the listing reached the end.
+func (a *app) printFileList(raws []json.RawMessage, files []api.File, next string) error {
+	if a.jsonOut {
+		if raws == nil {
+			raws = []json.RawMessage{}
+		}
+		var cursor *string
+		if next != "" {
+			cursor = &next
+		}
+		return a.printJSONValue(struct {
+			Files      []json.RawMessage `json:"files"`
+			NextCursor *string           `json:"next_cursor"`
+		}{Files: raws, NextCursor: cursor})
+	}
+	for _, f := range files {
+		a.printListLine(f)
+	}
+	if len(files) == 0 {
+		fmt.Fprintln(a.stderr, "no files")
+	}
+	if next != "" {
+		// stderr, so stdout stays one line per file for a pipeline.
+		fmt.Fprintf(a.stderr, "more files remain; continue with --cursor %s\n", next)
+	}
+	return nil
+}
+
+// printListLine renders one ls row.
+func (a *app) printListLine(f api.File) {
+	fmt.Fprintf(a.stdout, "%s %s %s %s\n", f.ID, fmtBytes(f.SizeBytes), fmtTime(f.ExpiresAt), f.Name)
 }
 
 func (a *app) infoCmd() *cobra.Command {

--- a/cmd/files.go
+++ b/cmd/files.go
@@ -204,8 +204,8 @@ func (a *app) lsCmd() *cobra.Command {
 			"  aispace ls --limit 50 --cursor \"$(aispace ls --limit 50 --json | jq -r .next_cursor)\" --json",
 		Args: noArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if limit < 0 {
-				return usagef("--limit must be >= 0")
+			if cmd.Flags().Changed("limit") && limit < 1 {
+				return usagef("--limit must be >= 1")
 			}
 			c, err := a.client()
 			if err != nil {
@@ -216,7 +216,7 @@ func (a *app) lsCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				return a.printFileList(raws, files, next)
+				return a.printFileList(raws, files, next, limit)
 			}
 			if a.jsonOut {
 				var raws []json.RawMessage
@@ -227,7 +227,7 @@ func (a *app) lsCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				return a.printFileList(raws, nil, "")
+				return a.printFileList(raws, nil, "", 0)
 			}
 			count := 0
 			err = c.WalkFilesFrom(cmd.Context(), cursor, func(_ []json.RawMessage, files []api.File) error {
@@ -254,7 +254,7 @@ func (a *app) lsCmd() *cobra.Command {
 
 // printFileList renders a listing in whichever mode is active. next is the
 // cursor to resume from, empty when the listing reached the end.
-func (a *app) printFileList(raws []json.RawMessage, files []api.File, next string) error {
+func (a *app) printFileList(raws []json.RawMessage, files []api.File, next string, limit int) error {
 	if a.jsonOut {
 		if raws == nil {
 			raws = []json.RawMessage{}
@@ -276,7 +276,7 @@ func (a *app) printFileList(raws []json.RawMessage, files []api.File, next strin
 	}
 	if next != "" {
 		// stderr, so stdout stays one line per file for a pipeline.
-		fmt.Fprintf(a.stderr, "more files remain; continue with --cursor %s\n", next)
+		fmt.Fprintf(a.stderr, "more files remain; continue with --limit %d --cursor %s\n", limit, next)
 	}
 	return nil
 }

--- a/cmd/ls_pagination_test.go
+++ b/cmd/ls_pagination_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,7 +46,13 @@ func newPagedServer(t *testing.T, total, pageMax int) *pagedServer {
 		}
 		size := p.pageMax
 		if l := q.Get("limit"); l != "" {
-			if n, err := strconv.Atoi(l); err == nil && n < size {
+			n, err := strconv.Atoi(l)
+			if err != nil || n < 1 || n > 100 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"code":"bad_request","message":"limit must be between 1 and 100"}}`))
+				return
+			}
+			if n < size {
 				size = n
 			}
 		}
@@ -171,6 +178,28 @@ func TestLsLimitBeyondEndReportsNoCursor(t *testing.T) {
 	}
 }
 
+func TestLsLimitAboveServerMaximumUsesMultipleRequests(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 300, 100)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "250", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got := parseLs(t, r.stdout)
+	if len(got.Files) != 250 {
+		t.Fatalf("got %d files, want 250", len(got.Files))
+	}
+	if got.NextCursor == nil || *got.NextCursor != "250" {
+		t.Fatalf("next_cursor = %v, want a resume point at 250", got.NextCursor)
+	}
+	wantCalls := []string{"cursor= limit=100", "cursor=100 limit=100", "cursor=200 limit=50"}
+	if calls := p.calls(); !slices.Equal(calls, wantCalls) {
+		t.Fatalf("calls = %v, want %v", calls, wantCalls)
+	}
+}
+
 // Without --limit nothing changes: every page is walked and next_cursor is null.
 func TestLsWithoutLimitStillWalksEverything(t *testing.T) {
 	isolate(t)
@@ -204,8 +233,8 @@ func TestLsLimitHumanOutputKeepsStdoutClean(t *testing.T) {
 	if !strings.HasPrefix(lines[0], "F000 ") {
 		t.Fatalf("first line = %q", lines[0])
 	}
-	if !strings.Contains(r.stderr, "--cursor 3") {
-		t.Fatalf("stderr should name the resume cursor: %q", r.stderr)
+	if !strings.Contains(r.stderr, "--limit 3 --cursor 3") {
+		t.Fatalf("stderr should preserve the page size and name the resume cursor: %q", r.stderr)
 	}
 }
 
@@ -215,7 +244,21 @@ func TestLsRejectsNegativeLimit(t *testing.T) {
 	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
 
 	r := run("", "ls", "--limit", "-1")
-	if r.code != ExitUsage || !strings.Contains(r.stderr, "--limit must be >= 0") {
+	if r.code != ExitUsage || !strings.Contains(r.stderr, "--limit must be >= 1") {
 		t.Fatalf("%+v", r)
+	}
+}
+
+func TestLsRejectsExplicitZeroLimit(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 1, 1)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "0")
+	if r.code != ExitUsage || !strings.Contains(r.stderr, "--limit must be >= 1") {
+		t.Fatalf("%+v", r)
+	}
+	if calls := p.calls(); len(calls) != 0 {
+		t.Fatalf("server received requests for invalid limit: %v", calls)
 	}
 }

--- a/cmd/ls_pagination_test.go
+++ b/cmd/ls_pagination_test.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// pagedServer serves total files through cursor pagination, honouring the
+// limit query parameter and capping each page at pageMax the way a real API
+// would.
+type pagedServer struct {
+	mu       sync.Mutex
+	srv      *httptest.Server
+	key      string
+	total    int
+	pageMax  int
+	requests []string
+}
+
+func newPagedServer(t *testing.T, total, pageMax int) *pagedServer {
+	t.Helper()
+	p := &pagedServer{key: "ask_validkey0000000000000000000000", total: total, pageMax: pageMax}
+	p.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+p.key {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_key","message":"Invalid key"}}`))
+			return
+		}
+		q := r.URL.Query()
+		p.mu.Lock()
+		p.requests = append(p.requests, "cursor="+q.Get("cursor")+" limit="+q.Get("limit"))
+		p.mu.Unlock()
+
+		start := 0
+		if cur := q.Get("cursor"); cur != "" {
+			start, _ = strconv.Atoi(cur)
+		}
+		size := p.pageMax
+		if l := q.Get("limit"); l != "" {
+			if n, err := strconv.Atoi(l); err == nil && n < size {
+				size = n
+			}
+		}
+		end := start + size
+		if end > p.total {
+			end = p.total
+		}
+		var items []string
+		for i := start; i < end; i++ {
+			items = append(items, fmt.Sprintf(`{"id":"F%03d","name":"f%03d.txt","content_type":"text/plain","size_bytes":%d,"visibility":"account","created_at":1,"expires_at":1757604800}`, i, i, i+1))
+		}
+		next := "null"
+		if end < p.total {
+			next = strconv.Quote(strconv.Itoa(end))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"files":[%s],"next_cursor":%s}`, strings.Join(items, ","), next)
+	}))
+	t.Cleanup(p.srv.Close)
+	return p
+}
+
+func (p *pagedServer) calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.requests...)
+}
+
+type lsJSON struct {
+	Files []struct {
+		ID string `json:"id"`
+	} `json:"files"`
+	NextCursor *string `json:"next_cursor"`
+}
+
+func parseLs(t *testing.T, out string) lsJSON {
+	t.Helper()
+	var got lsJSON
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("stdout %q: %v", out, err)
+	}
+	return got
+}
+
+// --limit must stop early rather than walking the whole account, which is the
+// point: on a large account the default costs one request per page.
+func TestLsLimitStopsEarly(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 100, 10)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "25", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got := parseLs(t, r.stdout)
+	if len(got.Files) != 25 {
+		t.Fatalf("got %d files, want 25", len(got.Files))
+	}
+	if got.NextCursor == nil || *got.NextCursor != "25" {
+		t.Fatalf("next_cursor = %v, want a resume point at 25", got.NextCursor)
+	}
+	// 25 files at 10 per page is three requests, not the ten the full walk costs.
+	if n := len(p.calls()); n != 3 {
+		t.Fatalf("made %d requests (%v), want 3", n, p.calls())
+	}
+}
+
+// The cursor handed back must resume exactly where the previous page stopped,
+// with no gap and no repeat.
+func TestLsCursorResumesWithoutGapOrOverlap(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 30, 7)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	var seen []string
+	cursor := ""
+	for page := 0; page < 10; page++ {
+		args := []string{"ls", "--limit", "8", "--json"}
+		if cursor != "" {
+			args = append(args, "--cursor", cursor)
+		}
+		r := run("", args...)
+		if r.code != ExitOK {
+			t.Fatalf("page %d: %+v", page, r)
+		}
+		got := parseLs(t, r.stdout)
+		for _, f := range got.Files {
+			seen = append(seen, f.ID)
+		}
+		if got.NextCursor == nil {
+			break
+		}
+		cursor = *got.NextCursor
+	}
+	if len(seen) != 30 {
+		t.Fatalf("collected %d ids, want 30: %v", len(seen), seen)
+	}
+	for i, id := range seen {
+		if want := fmt.Sprintf("F%03d", i); id != want {
+			t.Fatalf("id[%d] = %s, want %s (order, gap or overlap)", i, id, want)
+		}
+	}
+}
+
+// A limit larger than the account must end cleanly rather than reporting a
+// resume point that leads nowhere.
+func TestLsLimitBeyondEndReportsNoCursor(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 12, 5)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "100", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got := parseLs(t, r.stdout)
+	if len(got.Files) != 12 {
+		t.Fatalf("got %d files, want 12", len(got.Files))
+	}
+	if got.NextCursor != nil {
+		t.Fatalf("next_cursor = %v, want null at the end of the listing", *got.NextCursor)
+	}
+}
+
+// Without --limit nothing changes: every page is walked and next_cursor is null.
+func TestLsWithoutLimitStillWalksEverything(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 23, 10)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got := parseLs(t, r.stdout)
+	if len(got.Files) != 23 || got.NextCursor != nil {
+		t.Fatalf("files=%d next_cursor=%v, want 23 and null", len(got.Files), got.NextCursor)
+	}
+}
+
+// Human mode keeps stdout one line per file and puts the resume hint on stderr.
+func TestLsLimitHumanOutputKeepsStdoutClean(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 50, 10)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "3")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	lines := strings.Split(strings.TrimSpace(r.stdout), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("stdout has %d lines, want 3: %q", len(lines), r.stdout)
+	}
+	if !strings.HasPrefix(lines[0], "F000 ") {
+		t.Fatalf("first line = %q", lines[0])
+	}
+	if !strings.Contains(r.stderr, "--cursor 3") {
+		t.Fatalf("stderr should name the resume cursor: %q", r.stderr)
+	}
+}
+
+func TestLsRejectsNegativeLimit(t *testing.T) {
+	isolate(t)
+	p := newPagedServer(t, 1, 1)
+	writeConfig(t, config.File{Key: p.key, URL: p.srv.URL})
+
+	r := run("", "ls", "--limit", "-1")
+	if r.code != ExitUsage || !strings.Contains(r.stderr, "--limit must be >= 0") {
+		t.Fatalf("%+v", r)
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -360,10 +360,10 @@ Exit 1 with `not_found` if the file is unknown to this key or already expired.
 ### `aispace ls`
 
 ```
-aispace ls [--all] [--json]
+aispace ls [--limit N] [--cursor C] [--all] [--json]
 ```
 
-Lists this key's live files (`GET /v1/files`). It **always** follows `next_cursor` to the end, in
+Lists this key's live files (`GET /v1/files`). By default it follows `next_cursor` to the end, in
 both human and `--json` mode. `--all` is accepted for compatibility and does nothing.
 
 Human output is one line per file, `<id> <size> <expires> <name>`, with no header:
@@ -375,7 +375,7 @@ Human output is one line per file, `<id> <size> <expires> <name>`, with no heade
 
 When the key holds no files, nothing is written to stdout and `no files` goes to stderr, so a
 `--json`-free pipeline stays empty. `--json` prints every page merged into one object, with
-`next_cursor` always `null` because the walk is already finished:
+`next_cursor` `null` because the walk is already finished:
 
 ```sh
 # total bytes held by this key
@@ -383,6 +383,39 @@ aispace ls --json | jq '[.files[].size_bytes] | add'
 
 # files expiring within 24 h
 aispace ls --json | jq -r --argjson t "$(date +%s)" '.files[] | select(.expires_at - $t < 86400) | .name'
+```
+
+#### Paging a large account
+
+Walking to the end costs one request per page, which is wasteful when only the first few files are
+wanted. `--limit N` stops after N files instead:
+
+```sh
+aispace ls --limit 50 --json
+```
+
+Each request asks for exactly the number still wanted, so `next_cursor` stays aligned with what was
+consumed — it is the resume point, not the end of the last page. Pass it back with `--cursor` to
+continue, and it is `null` once the listing is exhausted:
+
+```sh
+cursor=""
+while :; do
+  page=$(aispace ls --limit 100 ${cursor:+--cursor "$cursor"} --json)
+  echo "$page" | jq -r '.files[].id'
+  cursor=$(echo "$page" | jq -r '.next_cursor // empty')
+  [ -n "$cursor" ] || break
+done
+```
+
+Resuming is exact: no file is skipped and none is returned twice. In human mode stdout stays one
+line per file and the resume hint goes to stderr, so a pipeline is unaffected:
+
+```
+$ aispace ls --limit 3
+01J8ZQ3V9N7X2K4M6P8R0T2W4Y 1.0 MB 2026-09-12T17:00:00Z report.pdf
+...
+more files remain; continue with --cursor 3        # stderr
 ```
 
 ### `aispace rm`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -428,7 +428,7 @@ line per file and the resume hint goes to stderr, so a pipeline is unaffected:
 $ aispace ls --limit 3
 01J8ZQ3V9N7X2K4M6P8R0T2W4Y 1.0 MB 2026-09-12T17:00:00Z report.pdf
 ...
-more files remain; continue with --cursor 3        # stderr
+more files remain; continue with --limit 3 --cursor 3        # stderr
 ```
 
 ### `aispace rm`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -205,6 +205,8 @@ func (c *Client) Download(ctx context.Context, id string) (*http.Response, error
 	}
 }
 
+const maxListFilesLimit = 100
+
 // ListFiles fetches one page of GET /v1/files.
 func (c *Client) ListFiles(ctx context.Context, cursor string, limit int) (Result[FileList], error) {
 	q := url.Values{}
@@ -230,11 +232,8 @@ func (c *Client) ListFiles(ctx context.Context, cursor string, limit int) (Resul
 // decoded values, and the cursor to resume from, which is empty once the
 // listing is exhausted.
 //
-// Each request asks for exactly the number still wanted, so the cursor the
-// server hands back stays aligned with what was consumed. A server that
-// returns more than it was asked for keeps its extra entries rather than
-// having them truncated, because dropping them would leave the resume cursor
-// pointing past files the caller never saw.
+// Each request asks for the smaller of the number still wanted and the API's
+// per-request maximum, so the cursor stays aligned with what was consumed.
 func (c *Client) ListPage(ctx context.Context, cursor string, limit int) ([]json.RawMessage, []File, string, error) {
 	if limit <= 0 {
 		return nil, nil, "", &Error{Code: "bad_request", Message: "limit must be positive"}
@@ -243,11 +242,15 @@ func (c *Client) ListPage(ctx context.Context, cursor string, limit int) ([]json
 	var files []File
 	seen := map[string]struct{}{}
 	for len(raws) < limit {
-		res, err := c.ListFiles(ctx, cursor, limit-len(raws))
+		requestLimit := min(limit-len(raws), maxListFilesLimit)
+		res, err := c.ListFiles(ctx, cursor, requestLimit)
 		if err != nil {
 			return nil, nil, "", err
 		}
 		page := res.Value.Files
+		if len(page) > requestLimit {
+			return nil, nil, "", &Error{Code: "bad_response", Message: fmt.Sprintf("server returned %d files after a request for at most %d", len(page), requestLimit)}
+		}
 		for _, raw := range page {
 			var f File
 			if err := json.Unmarshal(raw, &f); err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -225,9 +225,61 @@ func (c *Client) ListFiles(ctx context.Context, cursor string, limit int) (Resul
 	return do[FileList](c, req, http.StatusOK)
 }
 
+// ListPage fetches at most limit files starting at cursor, following
+// next_cursor only as far as it needs to. It returns the raw entries, the
+// decoded values, and the cursor to resume from, which is empty once the
+// listing is exhausted.
+//
+// Each request asks for exactly the number still wanted, so the cursor the
+// server hands back stays aligned with what was consumed. A server that
+// returns more than it was asked for keeps its extra entries rather than
+// having them truncated, because dropping them would leave the resume cursor
+// pointing past files the caller never saw.
+func (c *Client) ListPage(ctx context.Context, cursor string, limit int) ([]json.RawMessage, []File, string, error) {
+	if limit <= 0 {
+		return nil, nil, "", &Error{Code: "bad_request", Message: "limit must be positive"}
+	}
+	var raws []json.RawMessage
+	var files []File
+	seen := map[string]struct{}{}
+	for len(raws) < limit {
+		res, err := c.ListFiles(ctx, cursor, limit-len(raws))
+		if err != nil {
+			return nil, nil, "", err
+		}
+		page := res.Value.Files
+		for _, raw := range page {
+			var f File
+			if err := json.Unmarshal(raw, &f); err != nil {
+				return nil, nil, "", &Error{Code: "bad_response", Message: "cannot decode file entry: " + err.Error(), cause: err}
+			}
+			raws = append(raws, raw)
+			files = append(files, f)
+		}
+		next := res.Value.NextCursor
+		if next == nil || *next == "" {
+			return raws, files, "", nil
+		}
+		if _, ok := seen[*next]; ok {
+			return nil, nil, "", &Error{Code: "bad_response", Message: "pagination loop: repeated cursor"}
+		}
+		seen[*next] = struct{}{}
+		cursor = *next
+		if len(page) == 0 {
+			// A server handing out cursors without files would spin forever.
+			return raws, files, cursor, nil
+		}
+	}
+	return raws, files, cursor, nil
+}
+
 // WalkFiles follows next_cursor until exhausted and visits each decoded page.
 func (c *Client) WalkFiles(ctx context.Context, visit func([]json.RawMessage, []File) error) error {
-	cursor := ""
+	return c.WalkFilesFrom(ctx, "", visit)
+}
+
+// WalkFilesFrom is WalkFiles starting at an existing cursor.
+func (c *Client) WalkFilesFrom(ctx context.Context, cursor string, visit func([]json.RawMessage, []File) error) error {
 	seen := map[string]struct{}{}
 	for {
 		res, err := c.ListFiles(ctx, cursor, 0)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -400,6 +400,20 @@ func TestListAllFilesPaginates(t *testing.T) {
 	}
 }
 
+func TestListPageRejectsMoreFilesThanRequested(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("limit"); got != "1" {
+			t.Errorf("limit = %q, want 1", got)
+		}
+		_, _ = w.Write([]byte(`{"files":[{"id":"a"},{"id":"b"}],"next_cursor":"b"}`))
+	})
+	_, _, _, err := c.ListPage(context.Background(), "", 1)
+	var ae *Error
+	if !errors.As(err, &ae) || ae.Code != "bad_response" || !strings.Contains(ae.Message, "returned 2 files") {
+		t.Fatalf("error = %v, want bad_response for an overfull page", err)
+	}
+}
+
 func TestListAllFilesDetectsLoop(t *testing.T) {
 	c, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"files":[],"next_cursor":"same"}`))


### PR DESCRIPTION
## The gap

`ls` walks pagination to the end, always. On an account with many files that is one request per page and the whole listing held in memory, even when the caller only wanted the first few.

There was no way to ask for less, and the pieces to do it were already half-present:

- `Client.ListFiles(ctx, cursor, limit)` accepts a `limit` — **nothing ever passed one**. `WalkFiles` hard-codes `0`.
- `ls --json` emits `next_cursor`, but it is `null` by construction, because the walk always finishes. The cursor the API returns was never reachable from the CLI.

So the API supports paging, the client supports paging, and the command threw it away.

## What this adds

```sh
aispace ls --limit 50 --json
```

**Fetching 25 files from an account of 100 now costs 3 requests instead of 10.** The test asserts the request count, not just the output — "did it stop early" is the actual claim, and only counting requests proves it.

The part worth reviewing carefully is why `--cursor` is exact. Each request asks for **exactly the number still wanted**, never a fixed page size, so the cursor the server hands back is aligned with what was actually consumed — it is the resume point, not the end of a page that was partly discarded. `TestLsCursorResumesWithoutGapOrOverlap` pins that by paging a 30-file account 8 at a time and checking the ids come back in order, all 30, none twice.

```sh
cursor=""
while :; do
  page=$(aispace ls --limit 100 ${cursor:+--cursor "$cursor"} --json)
  echo "$page" | jq -r '.files[].id'
  cursor=$(echo "$page" | jq -r '.next_cursor // empty')
  [ -n "$cursor" ] || break
done
```

## Deliberate choices

**A server returning more than it was asked for keeps its extras.** Truncating back to `--limit` would look tidier, but the resume cursor would then point past files the caller never saw — silently losing them. Overshooting slightly is the safe failure mode; a comment in `ListPage` says why.

**Human mode keeps stdout clean.** One line per file on stdout, the resume hint on stderr, so a pipeline reading ids is unaffected:

```
$ aispace ls --limit 3
01J8ZQ3V9N7X2K4M6P8R0T2W4Y 1.0 MB 2026-09-12T17:00:00Z report.pdf
...
more files remain; continue with --cursor 3        # stderr
```

**`WalkFiles` keeps its signature** and delegates to a new `WalkFilesFrom`, so `--cursor` also works on an unbounded listing and nothing existing had to change.

## Default is unchanged

`TestLsWithoutLimitStillWalksEverything` pins it: no `--limit` means the full walk and `next_cursor: null`, exactly as documented. The four existing `ls` tests pass untouched.

## Tests

Seven in a new `cmd/ls_pagination_test.go`, against a server that implements real cursor pagination and honours `limit` while capping pages the way an API would:

| Test | Asserts |
|---|---|
| `TestLsLimitStopsEarly` | 25 of 100 files in **3 requests**, cursor at 25 |
| `TestLsCursorResumesWithoutGapOrOverlap` | 30 files, 8 at a time, in order, no gap or repeat |
| `TestLsLimitBeyondEndReportsNoCursor` | `--limit 100` on 12 files ends with `null`, not a dead cursor |
| `TestLsWithoutLimitStillWalksEverything` | default path unchanged |
| `TestLsLimitHumanOutputKeepsStdoutClean` | 3 lines on stdout, hint on stderr |
| `TestLsRejectsNegativeLimit` | exit 2 |

`gofmt`, `go vet ./...`, `go test ./...` clean on Windows. `docs/CLI.md` gains a "Paging a large account" subsection with the loop above.
