### PR TITLE
fix: persist generated recovery identities

### DIFF
--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -94,7 +94,7 @@ func (a *app) keygenCmd() *cobra.Command {
 	return cmd
 }
 
-func encryptForUpload(src io.Reader, originalName, recipientText, identityOut string) (*encryptedUpload, error) {
+func encryptForUpload(src io.Reader, originalName, recipientText, identityOut, recoveryDir string) (*encryptedUpload, error) {
 	var recipient age.Recipient
 	var identity string
 	if recipientText != "" {
@@ -122,7 +122,7 @@ func encryptForUpload(src io.Reader, originalName, recipientText, identityOut st
 		}
 	} else if identity != "" {
 		var err error
-		recoveryFile, err = writeRecoveryIdentity(identity + "\n")
+		recoveryFile, err = writeRecoveryIdentity(recoveryDir, identity+"\n")
 		if err != nil {
 			return nil, err
 		}
@@ -185,8 +185,19 @@ func encryptForUpload(src io.Reader, originalName, recipientText, identityOut st
 	}, nil
 }
 
-func writeRecoveryIdentity(value string) (string, error) {
-	f, err := os.CreateTemp("", "aispace-identity-recovery-*.agekey")
+func writeRecoveryIdentity(dir, value string) (string, error) {
+	if dir == "" {
+		return "", &codedError{code: "config", err: errors.New("recovery identity directory is not configured"), exit: ExitGeneric}
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", &codedError{code: "io", err: fmt.Errorf("create recovery identity directory: %w", err), exit: ExitGeneric}
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return "", &codedError{code: "io", err: fmt.Errorf("secure recovery identity directory: %w", err), exit: ExitGeneric}
+		}
+	}
+	f, err := os.CreateTemp(dir, "identity-*.agekey")
 	if err != nil {
 		return "", &codedError{code: "io", err: fmt.Errorf("create recovery identity file: %w", err), exit: ExitGeneric}
 	}

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -127,7 +127,11 @@ func (a *app) runUpload(cmd *cobra.Command, path string, f uploadFlags) error {
 
 	var encrypted *encryptedUpload
 	if f.encrypt {
-		encrypted, err = encryptForUpload(src, originalName, f.recipient, f.identityOut)
+		recoveryDir := ""
+		if f.recipient == "" && f.identityOut == "" {
+			recoveryDir = filepath.Join(filepath.Dir(a.cfg.Path), "recovery")
+		}
+		encrypted, err = encryptForUpload(src, originalName, f.recipient, f.identityOut, recoveryDir)
 		if err != nil {
 			return err
 		}

--- a/cmd/upload_identity_test.go
+++ b/cmd/upload_identity_test.go
@@ -109,7 +109,7 @@ func TestUploadKeepsIdentityWhenOutcomeIsUnknown(t *testing.T) {
 }
 
 func TestUploadKeepsGeneratedRecoveryIdentityWhenOutcomeIsUnknown(t *testing.T) {
-	isolate(t)
+	configHome := isolate(t)
 	f := newFakeServer(t)
 	writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
 	dir := t.TempDir()
@@ -130,6 +130,19 @@ func TestUploadKeepsGeneratedRecoveryIdentityWhenOutcomeIsUnknown(t *testing.T) 
 	}
 	path := strings.SplitN(r.stderr[start+len(prefix):], ";", 2)[0]
 	t.Cleanup(func() { _ = os.Remove(path) })
+	wantDir := filepath.Join(configHome, "xdg", "aispace", "recovery")
+	if filepath.Dir(path) != wantDir {
+		t.Fatalf("recovery identity directory = %q, want %q", filepath.Dir(path), wantDir)
+	}
+	if permBits {
+		info, err := os.Stat(wantDir)
+		if err != nil {
+			t.Fatalf("stat recovery directory: %v", err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("recovery directory mode = %04o, want 0700", info.Mode().Perm())
+		}
+	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read recovery identity: %v", err)
@@ -140,7 +153,7 @@ func TestUploadKeepsGeneratedRecoveryIdentityWhenOutcomeIsUnknown(t *testing.T) 
 }
 
 func TestGeneratedRecoveryIdentityIsTemporaryOnSuccess(t *testing.T) {
-	e, err := encryptForUpload(strings.NewReader("secret"), "secret.txt", "", "")
+	e, err := encryptForUpload(strings.NewReader("secret"), "secret.txt", "", "", t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +172,7 @@ func TestGeneratedRecoveryIdentityIsTemporaryOnSuccess(t *testing.T) {
 
 func TestLocalEncryptionFailureRemovesIdentityFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "secret.agekey")
-	_, err := encryptForUpload(failingUploadReader{}, "secret.txt", "", path)
+	_, err := encryptForUpload(failingUploadReader{}, "secret.txt", "", path, "")
 	if err == nil {
 		t.Fatal("expected encryption to fail")
 	}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -258,8 +258,10 @@ leaving it behind would make retrying the same command fail with `identity file 
 When the request fails without a response or returns a 5xx server error, the outcome is uncertain,
 so the identity is kept and a warning names it — check `aispace ls` before deleting it, because the
 file may have been stored. When no `--identity-out` was supplied, the CLI creates a mode-`0600`
-temporary recovery identity before uploading. It removes that recovery copy after a definite
-success or rejection, but keeps it and prints its path after an uncertain outcome.
+recovery identity under the private aispace configuration directory (`recovery/` beside
+`config.json`). It removes that recovery copy after a definite success or rejection, but keeps it
+and prints its path after an uncertain outcome. If the process is terminated abruptly, inspect that
+directory before removing a leftover key; it may be the only way to decrypt a stored upload.
 
 ### `aispace download`
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -15,8 +15,10 @@ operational configuration are maintained separately.
 `aispace upload --encrypt` encrypts locally with age X25519 before upload. The service receives
 ciphertext, not plaintext or the private identity. Generated identity files use mode `0600` and
 are never overwritten. When an identity would normally be printed after upload, the CLI holds a
-mode-`0600` temporary recovery copy until the server outcome is known. It retains and names that
-file only if a network or server failure leaves it uncertain whether ciphertext was stored.
+mode-`0600` recovery copy in a private directory beside its configuration file until the server
+outcome is known. It retains and names that file only if a network or server failure leaves it
+uncertain whether ciphertext was stored. After abrupt process termination, inspect `recovery/`
+beside `config.json` before removing leftover identities.
 
 Treat `AGE-SECRET-KEY-...` identities as credentials. Never upload them with their ciphertext.
 Deliver the URL and identity through separate authenticated channels when practical. Encryption


### PR DESCRIPTION
## Summary
- stage generated age recovery identities in a private directory beside the aispace config
- keep crash leftovers discoverable beyond OS temporary-file cleanup
- document recovery behavior and verify directory/file permissions

## Verification
- go test -race ./...
- go vet ./...
- GOOS=windows GOARCH=amd64 go build ./...