### PR TITLE
fix: a stall part-way through a transfer is coded io instead of timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,10 @@ const (
 // sleep is used by the API client when retrying rate-limited GETs; tests override it.
 var sleep func(time.Duration)
 
+// inactivityTimeout overrides the client's transfer stall timeout. Zero keeps
+// the client default; tests shorten it so a stall is reachable in a test.
+var inactivityTimeout time.Duration
+
 // app carries global flag state and IO for one invocation.
 type app struct {
 	version string
@@ -239,6 +243,9 @@ func (a *app) client() (*api.Client, error) {
 	}
 	c := api.New(cfg.URL, cfg.Key, a.userAgent())
 	c.Sleep = sleep
+	if inactivityTimeout > 0 {
+		c.InactivityTimeout = inactivityTimeout
+	}
 	return c, nil
 }
 
@@ -302,6 +309,14 @@ func validateKey(key string) error {
 func (a *app) classify(err error) (int, string) {
 	if errors.Is(err, context.Canceled) {
 		return ExitGeneric, "interrupted"
+	}
+	// A stall is checked before codedError for the same reason cancellation is:
+	// a command that hit it while writing its output wraps it as an I/O
+	// failure, and "io" hides the one thing the caller needs to know. The
+	// client reports "timeout" when a transfer stalls before the body starts,
+	// so a stall during the body must not be coded differently.
+	if errors.Is(err, api.ErrTransferStalled) {
+		return ExitGeneric, "timeout"
 	}
 	var ue *usageError
 	if errors.As(err, &ue) {

--- a/cmd/stall_classify_test.go
+++ b/cmd/stall_classify_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aispace-sh/aispace-client/internal/api"
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// A stall reaches the command wrapped as an I/O failure, because that is what
+// io.Copy reports while writing the output. Coding it "io" hides the reason the
+// transfer stopped, and disagrees with the "timeout" the client reports when a
+// transfer stalls before the body starts.
+func TestClassifyReportsStalledTransferAsTimeout(t *testing.T) {
+	a := &app{}
+	wrapped := &codedError{
+		code: "io",
+		err:  fmt.Errorf("writing output: %w", api.ErrTransferStalled),
+		exit: ExitGeneric,
+	}
+	exit, code := a.classify(wrapped)
+	if code != "timeout" {
+		t.Fatalf("code = %q, want %q", code, "timeout")
+	}
+	if exit != ExitGeneric {
+		t.Fatalf("exit = %d, want %d", exit, ExitGeneric)
+	}
+}
+
+// An ordinary I/O failure must keep its own code.
+func TestClassifyKeepsPlainIOCode(t *testing.T) {
+	a := &app{}
+	exit, code := a.classify(&codedError{code: "io", err: os.ErrPermission, exit: ExitGeneric})
+	if code != "io" || exit != ExitGeneric {
+		t.Fatalf("classify = %d/%q, want %d/io", exit, code, ExitGeneric)
+	}
+}
+
+// End to end: a server that sends headers and a few bytes and then goes quiet
+// must end the download as a timeout, not as a generic write failure.
+func TestDownloadStallIsReportedAsTimeout(t *testing.T) {
+	isolate(t)
+	old := inactivityTimeout
+	inactivityTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { inactivityTimeout = old })
+
+	release := make(chan struct{})
+	key := "ask_validkey0000000000000000000000"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+key {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "1000")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("start"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Go quiet: never send the rest of the promised body.
+		select {
+		case <-release:
+		case <-time.After(10 * time.Second):
+		}
+	}))
+	// Cleanups run last-registered-first, and srv.Close waits for in-flight
+	// handlers, so the handler has to be released before it runs.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	writeConfig(t, config.File{Key: key, URL: srv.URL})
+
+	out := filepath.Join(t.TempDir(), "stalled.bin")
+	r := run("", "download", "01A", "--output", out)
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	if !strings.Contains(r.stderr, "(timeout)") {
+		t.Fatalf("stderr = %q, want it coded as a timeout", r.stderr)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatalf("partial download was left on disk: err=%v", err)
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -133,6 +133,17 @@ given up on quickly:
 | Waiting for response headers | 60s |
 | Upload/download with no byte progress | 2m |
 
+A transfer that trips the inactivity timer fails with exit `1` and code `timeout`, whether it
+stalled before the body started or part-way through it:
+
+```
+error: transfer stalled without byte progress (timeout)
+error: transfer stalled (timeout)
+```
+
+A partly written output file is removed, so a stalled download never leaves a truncated file
+behind.
+
 `Ctrl-C`/`SIGTERM` cancels in-flight requests, closes stdin to unblock ordinary pipes, and exits `1`
 with code `interrupted`. After the first signal, default handling is restored so a second interrupt
 can terminate a source that cannot be closed cleanly.


### PR DESCRIPTION
Follow-up to the inactivity timer added in #19.

## The problem

A transfer that trips the inactivity timer is coded two different ways depending on *when* it stalls:

| When it stalls | What the user sees |
|---|---|
| before the body starts | `error: transfer stalled without byte progress (timeout)` |
| part-way through the body | `error: transfer stalled (io)` |

The second path goes through `watchedBody`, which surfaces `ErrTransferStalled` through `io.Copy`, and `download` wraps whatever `io.Copy` returns as an I/O failure — because from its point of view, writing the output is what failed.

Two consequences:

- **`io` points at the wrong thing.** It reads as a local disk problem, so the reader goes looking at their filesystem for a fault that is on the wire.
- **An agent cannot tell a stalled peer from a full disk.** Both are exit 1 with code `io`, and the right response differs: retry the transfer, versus free space first. This project treats the error code as a contract, so the two identical events need identical codes.

## The fix

`classify` already checks `context.Canceled` **ahead of** `codedError`, for exactly this reason — a command that wraps a cancellation while writing its output would otherwise report `io` as well. This applies the same reasoning to `ErrTransferStalled`:

```go
if errors.Is(err, context.Canceled) {
    return ExitGeneric, "interrupted"
}
if errors.Is(err, api.ErrTransferStalled) {
    return ExitGeneric, "timeout"
}
```

Doing it in `classify` rather than at each `io.Copy` site means every command gets it — `download`, `download --output -`, and anything added later — instead of each copy site having to remember. `TestClassifyKeepsPlainIOCode` pins that an ordinary I/O error still classifies as `io`, so this isn't a blanket reinterpretation.

## Why it was invisible

The stall path had **no command-level coverage**, because `InactivityTimeout` was two minutes with no way to shorten it from a test.

This adds an `inactivityTimeout` override next to the existing `sleep` hook, following the same pattern that file already uses for the retry timer. That makes the path reachable, and `TestDownloadStallIsReportedAsTimeout` now drives a real server that sends headers plus a few bytes, promises a `Content-Length` of 1000, and then goes quiet — asserting both the code *and* that the partial file is removed rather than left truncated on disk. It runs in 0.18s.

Against `main` (with the hook present so it compiles), both fail with the message users get today:

```
--- FAIL: TestClassifyReportsStalledTransferAsTimeout
    code = "io", want "timeout"
--- FAIL: TestDownloadStallIsReportedAsTimeout
    stderr = "error: transfer stalled (io)\n", want it coded as a timeout
```

One note on the test: the handler blocks until released, and `httptest.Server.Close` waits for in-flight handlers, so the cleanups are registered in the order that makes the release run first. Getting that backwards deadlocks the suite, which is worth knowing if this server shape gets copied.

`gofmt`, `go vet ./...`, `go test ./...` clean on Windows. `docs/CLI.md`'s Timeouts section now states the code and that a partial download is removed.
