### PR TITLE
chore: improve repository metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build output.
+/.gocache/
 /aispace
 /aispace.exe
 # Default `go build .` output, named after the module rather than the binary.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/aispace-sh/aispace-client/actions/workflows/ci.yml"><img src="https://github.com/aispace-sh/aispace-client/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4c6ef5.svg" alt="MIT license"></a>
-  <a href="https://goreportcard.com/report/github.com/aispace-sh/aispace-client"><img src="https://goreportcard.com/badge/github.com/aispace-sh/aispace-client" alt="Go Report Card"></a>
+  <a href="https://aispace.sh">Website</a> ·
+  <a href="https://aispace.sh/docs">Documentation</a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/aispace-sh/aispace-client/releases/latest"><img src="https://img.shields.io/github/v/release/aispace-sh/aispace-client?style=flat-square&color=FFD700" alt="Release"></a>
+  <a href="https://github.com/aispace-sh/aispace-client/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/aispace-sh/aispace-client/ci.yml?branch=main&style=flat-square&label=Go%20CI" alt="Go CI"></a>
+  <img src="https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat-square&logo=go&logoColor=white" alt="Go 1.26+">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT license"></a>
+  <a href="https://goreportcard.com/report/github.com/aispace-sh/aispace-client"><img src="https://goreportcard.com/badge/github.com/aispace-sh/aispace-client?style=flat-square" alt="Go Report Card"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- add prominent website and documentation links to the README
- add release, Go, license, CI, and Go Report Card badges
- ignore the repository-local Go build cache

## Verification

- `git diff --check`
- verified website, documentation, release, and badge targets resolve