### PR TITLE
feat(doctor): diagnose configuration, connectivity, auth and quota in one command

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,400 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aispace-sh/aispace-client/internal/api"
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// Check outcomes, worst last.
+const (
+	statusOK   = "ok"
+	statusWarn = "warn"
+	statusSkip = "skip"
+	statusFail = "fail"
+)
+
+// lowWaterMark is the fraction of a budget left at which a warning is useful:
+// enough headroom to finish what is running, not enough to ignore.
+const lowWaterMark = 0.10
+
+// check is one diagnosis. Hint is the next action, and is only set when there
+// is a concrete one.
+type check struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+	Hint   string `json:"hint,omitempty"`
+}
+
+type doctorReport struct {
+	Version   string  `json:"version"`
+	UserAgent string  `json:"user_agent"`
+	Checks    []check `json:"checks"`
+	Status    string  `json:"status"`
+}
+
+// doctorRun accumulates checks and the exit code the first failure earns.
+type doctorRun struct {
+	checks []check
+	// exit is the code of the first failing check, so `doctor` reports the same
+	// code the failing command itself would have returned.
+	exit int
+}
+
+func (d *doctorRun) add(c check, exit int) {
+	d.checks = append(d.checks, c)
+	if c.Status == statusFail && d.exit == ExitOK {
+		d.exit = exit
+	}
+}
+
+func (d *doctorRun) ok(name, detail string) {
+	d.add(check{Name: name, Status: statusOK, Detail: detail}, ExitOK)
+}
+
+func (d *doctorRun) warn(name, detail, hint string) {
+	d.add(check{Name: name, Status: statusWarn, Detail: detail, Hint: hint}, ExitOK)
+}
+
+func (d *doctorRun) fail(name, detail, hint string, exit int) {
+	d.add(check{Name: name, Status: statusFail, Detail: detail, Hint: hint}, exit)
+}
+
+func (d *doctorRun) skip(name, detail string) {
+	d.add(check{Name: name, Status: statusSkip, Detail: detail}, ExitOK)
+}
+
+// failed reports whether any check has failed so far, so later checks that
+// depend on it can be skipped rather than repeating the same error.
+func (d *doctorRun) failed() bool {
+	return d.exit != ExitOK
+}
+
+func (d *doctorRun) status() string {
+	worst := statusOK
+	for _, c := range d.checks {
+		switch c.Status {
+		case statusFail:
+			return statusFail
+		case statusWarn:
+			worst = statusWarn
+		}
+	}
+	return worst
+}
+
+func (a *app) doctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Check configuration, connectivity, authentication and quota",
+		Long: "Runs the checks that explain why a command is failing, in the order a command\n" +
+			"would hit them: where the key comes from, whether the server URL is usable,\n" +
+			"whether the key is accepted, and whether anything is out of allowance.\n\n" +
+			"Every check that can still run does run, so one problem does not hide another.\n" +
+			"The exit code is the one the failing command would itself have returned, so a\n" +
+			"caller can branch on it without learning a second set of codes. Warnings do not\n" +
+			"change the exit code.\n\n" +
+			"No file is uploaded and nothing is modified; the key is never printed.",
+		Args: noArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return a.runDoctor(cmd.Context())
+		},
+	}
+}
+
+func (a *app) runDoctor(ctx context.Context) error {
+	d := &doctorRun{}
+	cfg := a.checkConfig(d)
+	a.checkURL(d, cfg)
+	c := a.checkAuth(d, ctx, cfg)
+	a.checkQuota(d, ctx, c)
+
+	report := doctorReport{
+		Version:   a.version,
+		UserAgent: a.userAgent(),
+		Checks:    d.checks,
+		Status:    d.status(),
+	}
+	if a.jsonOut {
+		if err := a.printJSONValue(report); err != nil {
+			return err
+		}
+	} else {
+		a.printDoctor(report)
+	}
+	if d.failed() {
+		// The report is the output; re-printing a message would duplicate the
+		// failing line that is already on stdout.
+		return &reportedError{err: &codedError{
+			code: "doctor",
+			err:  errors.New("one or more checks failed"),
+			exit: d.exit,
+		}}
+	}
+	return nil
+}
+
+// checkConfig reports where the key comes from, which is the setting most often
+// wrong: an environment variable silently outranks a saved config file.
+func (a *app) checkConfig(d *doctorRun) config.Resolved {
+	cfg, err := config.Resolve(a.flagKey, a.flagURL)
+	if err != nil {
+		d.fail("config", err.Error(), "fix or remove the config file", ExitGeneric)
+		return cfg
+	}
+	fileKey := ""
+	if f, _, ferr := config.Load(cfg.Path); ferr == nil {
+		fileKey = f.Key
+	}
+
+	source, shadowed := keySource(a.flagKey, os.Getenv(config.EnvKey), fileKey)
+	switch source {
+	case "":
+		d.fail("config", "no API key configured",
+			"run `aispace login --key ask_...` or set "+config.EnvKey, ExitAuth)
+	default:
+		detail := fmt.Sprintf("key from %s", source)
+		if shadowed != "" {
+			// Not an error, but it explains a key that "did not take effect".
+			d.warn("config", detail,
+				fmt.Sprintf("%s is also set and is being ignored", shadowed))
+			break
+		}
+		d.ok("config", detail)
+	}
+
+	if _, err := os.Stat(cfg.Path); err != nil {
+		d.skip("config-file", fmt.Sprintf("%s (not present)", cfg.Path))
+		return cfg
+	}
+	if len(cfg.Warnings) > 0 {
+		d.warn("config-file", cfg.Path, strings.Join(cfg.Warnings, "; "))
+		return cfg
+	}
+	d.ok("config-file", cfg.Path)
+	return cfg
+}
+
+// keySource names the winning source under the documented precedence, plus the
+// lower-precedence source being shadowed, if any.
+func keySource(flag, env, file string) (source, shadowed string) {
+	switch {
+	case flag != "":
+		if env != "" {
+			return "--key", config.EnvKey
+		}
+		if file != "" {
+			return "--key", "the config file"
+		}
+		return "--key", ""
+	case env != "":
+		if file != "" {
+			return config.EnvKey, "the config file"
+		}
+		return config.EnvKey, ""
+	case file != "":
+		return "the config file", ""
+	}
+	return "", ""
+}
+
+func (a *app) checkURL(d *doctorRun, cfg config.Resolved) {
+	if err := validateServerURL(cfg.URL); err != nil {
+		d.fail("url", cfg.URL, err.Error(), ExitUsage)
+		return
+	}
+	detail := cfg.URL
+	if cfg.URL != config.DefaultURL {
+		detail += " (not the default " + config.DefaultURL + ")"
+	}
+	d.ok("url", detail)
+}
+
+// checkAuth is also the connectivity check: reaching /v1/whoami exercises DNS,
+// TCP, TLS and the key in one request, and each failure mode reports itself.
+func (a *app) checkAuth(d *doctorRun, ctx context.Context, cfg config.Resolved) *api.Client {
+	if d.failed() {
+		d.skip("auth", "skipped while an earlier check is failing")
+		return nil
+	}
+	if err := validateKey(cfg.Key); err != nil {
+		d.fail("auth", "the configured key is unusable", err.Error(), ExitUsage)
+		return nil
+	}
+	c := api.New(cfg.URL, cfg.Key, a.userAgent())
+	c.Sleep = sleep
+	if inactivityTimeout > 0 {
+		c.InactivityTimeout = inactivityTimeout
+	}
+	res, err := c.Whoami(ctx)
+	if err != nil {
+		var ae *api.Error
+		if errors.As(err, &ae) && ae.Status != 0 {
+			d.fail("auth", ae.Message, authHint(ae), ae.ExitCode())
+			return nil
+		}
+		// No HTTP status means nothing answered: DNS, TCP or TLS, not the key.
+		// Saying "auth failed" here would send the reader after the wrong thing.
+		d.fail("auth", errorMessage(err), "could not reach "+cfg.URL+"; check the network, proxy settings and the URL", ExitGeneric)
+		return nil
+	}
+	k := res.Value.Key
+	if k.RevokedAt != nil {
+		d.fail("auth", fmt.Sprintf("key %q (%s) is revoked", k.Name, k.Prefix),
+			"create a new key and run `aispace login --key ask_...`", ExitAuth)
+		return nil
+	}
+	d.ok("auth", fmt.Sprintf("%s (%s) for %s", k.Name, k.Prefix, res.Value.User.Email))
+	return c
+}
+
+// errorMessage prefers the API error message, which already omits any query
+// string, over the raw transport error.
+func errorMessage(err error) string {
+	var ae *api.Error
+	if errors.As(err, &ae) {
+		return ae.Message
+	}
+	return err.Error()
+}
+
+func authHint(e *api.Error) string {
+	switch e.Code {
+	case "invalid_key":
+		return "the key was rejected; check it was copied whole and has not been deleted"
+	case "key_revoked":
+		return "create a new key and run `aispace login --key ask_...`"
+	}
+	return ""
+}
+
+// checkQuota reports every allowance separately, because they fail for
+// different reasons and have different remedies.
+func (a *app) checkQuota(d *doctorRun, ctx context.Context, c *api.Client) {
+	if c == nil {
+		d.skip("quota", "skipped without a working key")
+		return
+	}
+	res, err := c.Quota(ctx)
+	if err != nil {
+		var ae *api.Error
+		if errors.As(err, &ae) {
+			d.fail("quota", ae.Message, "", ae.ExitCode())
+			return
+		}
+		d.fail("quota", err.Error(), "", ExitGeneric)
+		return
+	}
+	q := res.Value
+
+	if q.Key.BudgetLimited {
+		a.reportBytes(d, "quota-key", q.Key.RemainingBytes, q.Key.BudgetBytes,
+			"delete files with `aispace rm`, or raise the key budget in the dashboard")
+	} else {
+		d.ok("quota-key", fmt.Sprintf("%s used, no key budget", fmtBytes(q.Key.UsedBytes)))
+	}
+	a.reportBytes(d, "quota-account", q.Account.RemainingBytes, q.Account.AllowanceBytes,
+		"free space with `aispace rm`, or add capacity in the dashboard")
+
+	a.reportCount(d, "quota-uploads", q.Month.UploadsUsed, q.Month.UploadsLimit,
+		"monthly upload", q.Month.PeriodEnd)
+	a.reportCount(d, "quota-downloads", q.Month.DownloadsUsed, q.Month.DownloadsLimit,
+		"monthly download", q.Month.PeriodEnd)
+
+	if q.Rate.UploadsHourRemaining == 0 {
+		d.warn("rate", "no uploads left this hour", "wait for the next hour, or batch into one archive")
+		return
+	}
+	d.ok("rate", fmt.Sprintf("%d uploads left this hour, %d today, %d requests this minute",
+		q.Rate.UploadsHourRemaining, q.Rate.UploadsDayRemaining, q.Rate.RequestsMinuteRemaining))
+}
+
+func (a *app) reportBytes(d *doctorRun, name string, remaining, total int64, hint string) {
+	detail := fmt.Sprintf("%s of %s remaining", fmtBytes(remaining), fmtBytes(total))
+	switch {
+	case remaining <= 0:
+		d.fail(name, detail, hint, ExitQuota)
+	case total > 0 && float64(remaining)/float64(total) < lowWaterMark:
+		d.warn(name, detail, hint)
+	default:
+		d.ok(name, detail)
+	}
+}
+
+// reportCount covers the monthly caps, which exhaust as a count rather than a
+// size and reset on a date rather than by deleting anything.
+func (a *app) reportCount(d *doctorRun, name string, used, limit int64, what string, periodEnd int64) {
+	if limit <= 0 {
+		d.ok(name, fmt.Sprintf("%d used, no %s cap", used, what))
+		return
+	}
+	left := limit - used
+	detail := fmt.Sprintf("%d of %d %ss left, resets %s", left, limit, what, fmtTime(periodEnd))
+	hint := "nothing frees this before the reset; upgrade the plan to raise the cap"
+	switch {
+	case left <= 0:
+		// The server reports this as 429 monthly_*_cap, which is exit 5.
+		d.fail(name, fmt.Sprintf("%s cap reached (%d/%d), resets %s", what, used, limit, fmtTime(periodEnd)),
+			hint, ExitRateLimit)
+	case float64(left)/float64(limit) < lowWaterMark:
+		d.warn(name, detail, hint)
+	default:
+		d.ok(name, detail)
+	}
+}
+
+func (a *app) printDoctor(r doctorReport) {
+	fmt.Fprintf(a.stdout, "aispace %s (%s/%s)\n\n", r.Version, runtime.GOOS, runtime.GOARCH)
+	width := 0
+	for _, c := range r.Checks {
+		if len(c.Name) > width {
+			width = len(c.Name)
+		}
+	}
+	for _, c := range r.Checks {
+		fmt.Fprintf(a.stdout, "%-4s  %-*s  %s\n", c.Status, width, c.Name, c.Detail)
+		if c.Hint != "" {
+			fmt.Fprintf(a.stdout, "      %-*s  -> %s\n", width, "", c.Hint)
+		}
+	}
+	fails, warns := 0, 0
+	for _, c := range r.Checks {
+		switch c.Status {
+		case statusFail:
+			fails++
+		case statusWarn:
+			warns++
+		}
+	}
+	fmt.Fprintf(a.stdout, "\n%s\n", summarize(fails, warns))
+}
+
+func summarize(fails, warns int) string {
+	if fails == 0 && warns == 0 {
+		return "all checks passed"
+	}
+	parts := []string{}
+	if fails > 0 {
+		parts = append(parts, fmt.Sprintf("%s failing", plural(fails, "check")))
+	}
+	if warns > 0 {
+		parts = append(parts, fmt.Sprintf("%s", plural(warns, "warning")))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,314 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// doctorServer answers whoami and quota with values a test can bend, so each
+// allowance can be exhausted independently.
+type doctorServer struct {
+	srv       *httptest.Server
+	key       string
+	revoked   bool
+	whoamiErr int
+	quota     string
+}
+
+const healthyQuota = `{"key":{"budget_bytes":52428800,"used_bytes":1048576,"remaining_bytes":51380224,"budget_limited":true},` +
+	`"account":{"allowance_bytes":104857600,"used_bytes":3145728,"remaining_bytes":101711872,"plan":"free","extra_blocks":0},` +
+	`"month":{"uploads_used":12,"uploads_limit":100,"downloads_used":340,"downloads_limit":1000,"period_end":1759276800},` +
+	`"limits":{"max_file_bytes":26214400,"max_file_ttl_seconds":2592000,"max_link_ttl_seconds":604800,"uploads_per_hour":60,"uploads_per_day":500,"requests_per_minute":300},` +
+	`"rate":{"uploads_hour_remaining":58,"uploads_day_remaining":490,"requests_minute_remaining":299}}`
+
+func newDoctorServer(t *testing.T) *doctorServer {
+	t.Helper()
+	d := &doctorServer{key: "ask_validkey0000000000000000000000", quota: healthyQuota}
+	d.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("Authorization") != "Bearer "+d.key {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_key","message":"Invalid key"}}`))
+			return
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/whoami"):
+			if d.whoamiErr != 0 {
+				w.WriteHeader(d.whoamiErr)
+				_, _ = w.Write([]byte(`{"error":{"code":"internal","message":"backend down"}}`))
+				return
+			}
+			revoked := "null"
+			if d.revoked {
+				revoked = "1757000000"
+			}
+			fmt.Fprintf(w, `{"key":{"id":"k1","name":"research-bot","prefix":"ask_validkey","budget_bytes":52428800,`+
+				`"used_bytes":1048576,"created_at":1,"last_used_at":null,"revoked_at":%s},`+
+				`"user":{"email":"luigi@example.com"}}`, revoked)
+		case strings.HasSuffix(r.URL.Path, "/quota"):
+			_, _ = w.Write([]byte(d.quota))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(d.srv.Close)
+	return d
+}
+
+func doctorJSON(t *testing.T, out string) doctorReport {
+	t.Helper()
+	var r doctorReport
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatalf("stdout %q: %v", out, err)
+	}
+	return r
+}
+
+func checkNamed(t *testing.T, r doctorReport, name string) check {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no check named %q in %+v", name, r.Checks)
+	return check{}
+}
+
+func TestDoctorHealthyAccountPassesEverything(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+
+	r := run("", "doctor")
+	if r.code != ExitOK {
+		t.Fatalf("exit = %d, want 0: %+v", r.code, r)
+	}
+	if !strings.Contains(r.stdout, "all checks passed") {
+		t.Fatalf("stdout = %q", r.stdout)
+	}
+	if strings.Contains(r.stdout+r.stderr, d.key) {
+		t.Fatal("the key was printed")
+	}
+}
+
+// Without a key, doctor must return the same code an authenticated command
+// would, so a caller does not need a second set of codes.
+func TestDoctorNoKeyExitsAuth(t *testing.T) {
+	isolate(t)
+	r := run("", "doctor")
+	if r.code != ExitAuth {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitAuth, r)
+	}
+	if !strings.Contains(r.stdout, "no API key configured") {
+		t.Fatalf("stdout = %q", r.stdout)
+	}
+	// Checks that cannot run must say so rather than being silently absent.
+	got := doctorJSON(t, run("", "doctor", "--json").stdout)
+	if c := checkNamed(t, got, "auth"); c.Status != statusSkip {
+		t.Fatalf("auth = %+v, want skip", c)
+	}
+	if c := checkNamed(t, got, "quota"); c.Status != statusSkip {
+		t.Fatalf("quota = %+v, want skip", c)
+	}
+}
+
+func TestDoctorRejectedKeyExitsAuth(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	writeConfig(t, config.File{Key: "ask_wrongkey000000000000000000000", URL: d.srv.URL})
+
+	r := run("", "doctor")
+	if r.code != ExitAuth {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitAuth, r)
+	}
+	if !strings.Contains(r.stdout, "copied whole") {
+		t.Fatalf("expected an actionable hint: %q", r.stdout)
+	}
+}
+
+func TestDoctorRevokedKeyExitsAuth(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	d.revoked = true
+	writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+
+	r := run("", "doctor")
+	if r.code != ExitAuth {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitAuth, r)
+	}
+	if !strings.Contains(r.stdout, "revoked") {
+		t.Fatalf("stdout = %q", r.stdout)
+	}
+}
+
+// An environment variable silently outranking a saved config file is the
+// setting most often wrong, and the least visible.
+func TestDoctorReportsShadowedConfigKey(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+	t.Setenv(config.EnvKey, d.key)
+
+	got := doctorJSON(t, run("", "doctor", "--json").stdout)
+	c := checkNamed(t, got, "config")
+	if c.Status != statusWarn {
+		t.Fatalf("config = %+v, want warn", c)
+	}
+	if !strings.Contains(c.Detail, config.EnvKey) || !strings.Contains(c.Hint, "ignored") {
+		t.Fatalf("config check should name the shadowing: %+v", c)
+	}
+	// A shadowed key is still a working key, so nothing should fail.
+	if got.Status != statusWarn {
+		t.Fatalf("overall status = %q, want warn", got.Status)
+	}
+}
+
+func TestDoctorBadURLExitsUsage(t *testing.T) {
+	isolate(t)
+	writeConfig(t, config.File{Key: "ask_validkey0000000000000000000000", URL: "http://example.test"})
+
+	r := run("", "doctor")
+	if r.code != ExitUsage {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitUsage, r)
+	}
+	if !strings.Contains(r.stdout, "HTTPS") {
+		t.Fatalf("stdout = %q", r.stdout)
+	}
+}
+
+// Storage and the monthly caps exhaust differently and are fixed differently,
+// so they carry the exit code of the failure they predict.
+func TestDoctorExhaustedAllowancesUseTheirOwnExitCodes(t *testing.T) {
+	tests := []struct {
+		name  string
+		quota string
+		want  int
+		check string
+	}{
+		{
+			name: "account storage full",
+			quota: strings.Replace(healthyQuota,
+				`"remaining_bytes":101711872`, `"remaining_bytes":0`, 1),
+			want:  ExitQuota,
+			check: "quota-account",
+		},
+		{
+			name: "monthly upload cap reached",
+			quota: strings.Replace(healthyQuota,
+				`"uploads_used":12`, `"uploads_used":100`, 1),
+			want:  ExitRateLimit,
+			check: "quota-uploads",
+		},
+		{
+			name: "monthly download cap reached",
+			quota: strings.Replace(healthyQuota,
+				`"downloads_used":340`, `"downloads_used":1000`, 1),
+			want:  ExitRateLimit,
+			check: "quota-downloads",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolate(t)
+			d := newDoctorServer(t)
+			d.quota = tt.quota
+			writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+
+			r := run("", "doctor")
+			if r.code != tt.want {
+				t.Fatalf("exit = %d, want %d: %+v", r.code, tt.want, r)
+			}
+			got := doctorJSON(t, run("", "doctor", "--json").stdout)
+			if c := checkNamed(t, got, tt.check); c.Status != statusFail {
+				t.Fatalf("%s = %+v, want fail", tt.check, c)
+			}
+			// Auth succeeded, so it must still be reported as ok.
+			if c := checkNamed(t, got, "auth"); c.Status != statusOK {
+				t.Fatalf("auth = %+v, want ok; one failure must not hide the rest", c)
+			}
+		})
+	}
+}
+
+// A nearly full allowance is worth saying, but it is not a failure and must
+// not change the exit code.
+func TestDoctorLowAllowanceWarnsWithoutFailing(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	d.quota = strings.Replace(healthyQuota, `"remaining_bytes":101711872`, `"remaining_bytes":1048576`, 1)
+	writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+
+	r := run("", "doctor")
+	if r.code != ExitOK {
+		t.Fatalf("exit = %d, want 0 for a warning: %+v", r.code, r)
+	}
+	got := doctorJSON(t, run("", "doctor", "--json").stdout)
+	if c := checkNamed(t, got, "quota-account"); c.Status != statusWarn {
+		t.Fatalf("quota-account = %+v, want warn", c)
+	}
+	if got.Status != statusWarn {
+		t.Fatalf("status = %q, want warn", got.Status)
+	}
+}
+
+// An unreachable server is a network problem, not an auth one.
+func TestDoctorUnreachableServerExitsGeneric(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	url := d.srv.URL
+	d.srv.Close()
+	writeConfig(t, config.File{Key: d.key, URL: url})
+
+	r := run("", "doctor")
+	if r.code != ExitGeneric {
+		t.Fatalf("exit = %d, want %d: %+v", r.code, ExitGeneric, r)
+	}
+	got := doctorJSON(t, run("", "doctor", "--json").stdout)
+	if c := checkNamed(t, got, "auth"); c.Status != statusFail || !strings.Contains(c.Hint, url) {
+		t.Fatalf("auth = %+v, want a failure naming the server", c)
+	}
+}
+
+func TestDoctorJSONShape(t *testing.T) {
+	isolate(t)
+	d := newDoctorServer(t)
+	writeConfig(t, config.File{Key: d.key, URL: d.srv.URL})
+
+	r := run("", "doctor", "--json")
+	if r.code != ExitOK {
+		t.Fatalf("%+v", r)
+	}
+	got := doctorJSON(t, r.stdout)
+	if got.Status != statusOK || got.Version == "" || got.UserAgent == "" {
+		t.Fatalf("report = %+v", got)
+	}
+	for _, name := range []string{"config", "config-file", "url", "auth", "quota-key", "quota-account", "quota-uploads", "quota-downloads", "rate"} {
+		c := checkNamed(t, got, name)
+		if c.Status == "" || c.Detail == "" {
+			t.Fatalf("%s is incomplete: %+v", name, c)
+		}
+	}
+	if strings.Contains(r.stdout, d.key) {
+		t.Fatal("the key was printed in JSON mode")
+	}
+}
+
+// The report is the output; the failure must not also be echoed as an error
+// line, which would duplicate what is already on stdout.
+func TestDoctorDoesNotRepeatTheFailureOnStderr(t *testing.T) {
+	isolate(t)
+	r := run("", "doctor")
+	if r.code != ExitAuth {
+		t.Fatalf("%+v", r)
+	}
+	if strings.Contains(r.stderr, "one or more checks failed") {
+		t.Fatalf("failure echoed to stderr: %q", r.stderr)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,6 +176,7 @@ func (a *app) newRootCmd() *cobra.Command {
 		a.whoamiCmd(),
 		a.versionCmd(),
 		a.completionCmd(),
+		a.doctorCmd(),
 	)
 	// Replace cobra's generated completion command with one that can also
 	// install the script. The hidden __complete command it relies on is

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -681,6 +681,54 @@ aispace quota --json | jq '.month | {uploads_left: (.uploads_limit - .uploads_us
 aispace quota --json | jq '[.limits.max_file_bytes, .account.remaining_bytes] | min'
 ```
 
+### `aispace doctor`
+
+```
+aispace doctor [--json]
+```
+
+Runs the checks that explain why a command is failing, in the order a command hits them: where the
+key comes from, whether the server URL is usable, whether the key is accepted, and whether any
+allowance is spent. Nothing is uploaded, nothing is modified, and the key is never printed.
+
+```
+$ aispace doctor
+aispace 0.4.0 (darwin/arm64)
+
+ok    config       key from AISPACE_KEY
+      config       -> the config file is also set and is being ignored
+ok    config-file  /home/you/.config/aispace/config.json
+ok    url          https://aispace.sh
+ok    auth         research-bot (ask_9fK2mQ1x) for you@example.com
+warn  quota-key    3.0 MB of 50.0 MB remaining
+      quota-key    -> delete files with `aispace rm`, or raise the key budget in the dashboard
+fail  quota-uploads  monthly upload cap reached (100/100), resets 2026-10-01T00:00:00Z
+
+1 check failing, 1 warning
+```
+
+Every check that can still run does run, so one problem does not hide another; checks that cannot
+run report `skip` rather than being omitted.
+
+**The exit code is the one the failing command would itself have returned**, so a caller branches on
+the codes it already knows rather than a second set:
+
+| First failing check | Exit |
+|---|---|
+| no key, rejected key, revoked key | `3` |
+| unusable `--url`, or a key containing a control character | `2` |
+| storage allowance exhausted | `4` |
+| monthly upload or download cap reached | `5` |
+| server unreachable, or any other failure | `1` |
+
+Warnings never change the exit code, so `doctor` exiting `0` means "nothing is blocking a command
+right now", not "nothing worth reading".
+
+```sh
+aispace doctor --json | jq -r '.checks[] | select(.status=="fail") | "\(.name): \(.detail)"'
+aispace doctor >/dev/null || echo "not ready, exit $?"
+```
+
 ### `aispace whoami`
 
 Prints key name, prefix, account email and the key's usage against its budget


### PR DESCRIPTION
Implements the roadmap item **"Improve diagnostics for network, quota, and configuration failures"** (Next: easier integrations).

## Why

A failing command reports the first thing that went wrong and stops. That is correct for a command and poor for diagnosis: `aispace upload` returning exit `3` does not say whether the key is **missing**, **rejected**, **revoked**, or simply **shadowed** by an environment variable outranking the config file you just edited.

That last case is the most common and the least visible — precedence is silent by design, so the file looks right, the command still fails, and nothing points at `AISPACE_KEY`.

## What it does

```
$ aispace doctor
aispace 0.4.0 (darwin/arm64)

ok    config       key from AISPACE_KEY
      config       -> the config file is also set and is being ignored
ok    config-file  /home/you/.config/aispace/config.json
ok    url          https://aispace.sh
ok    auth         research-bot (ask_9fK2mQ1x) for you@example.com
warn  quota-key    3.0 MB of 50.0 MB remaining
      quota-key    -> delete files with `aispace rm`, or raise the key budget in the dashboard
fail  quota-uploads  monthly upload cap reached (100/100), resets 2026-10-01T00:00:00Z

1 check failing, 1 warning
```

Every check that can still run does run, so one problem does not hide another. Checks that *cannot* run report `skip` rather than being omitted, so the output always accounts for every stage — `TestDoctorNoKeyExitsAuth` asserts that.

## The exit code is the one the failing command would have returned

| First failing check | Exit |
|---|---|
| no key, rejected key, revoked key | `3` |
| unusable `--url`, control character in the key | `2` |
| storage allowance exhausted | `4` |
| monthly upload or download cap reached | `5` |
| server unreachable, anything else | `1` |

So a caller branches on codes it already knows instead of learning a second set. `aispace doctor >/dev/null || echo "not ready, exit $?"` slots straight into an existing agent preflight.

Warnings never change the exit code — exit `0` means "nothing is blocking a command right now", not "nothing worth reading".

## Two details that decide whether the output is actually useful

**A transport failure is reported as connectivity, not authentication.** It arrives as an `api.Error` with no HTTP status, which my first version folded into the auth branch — producing "auth failed" with an empty hint for a server that simply was not listening. That sends the reader after entirely the wrong thing. It now reads:

```
fail  auth  Get https://localhost:1/v1/whoami: dial tcp [::1]:1: connection refused
            -> could not reach https://localhost:1; check the network, proxy settings and the URL
```

**Storage and the monthly caps are separate checks**, because they exhaust differently and are fixed differently. Deleting files frees bytes; nothing frees a monthly count before the reset date. Collapsing them into one "quota" line would attach the wrong remedy to half the failures, so each carries its own hint and its own exit code (`4` vs `5`, matching `402` vs `429 monthly_*_cap`).

## Safety

Nothing is uploaded and nothing is modified — `doctor` only reads `/v1/whoami` and `/v1/quota`. **The key is never printed** in either output mode; two tests assert it does not appear in stdout or stderr, including the JSON report.

## Tests

Eleven cases in `cmd/doctor_test.go` against a server whose allowances each bend independently: healthy account; no key; rejected key; revoked key; shadowed config key; bad URL; account storage exhausted; monthly upload cap; monthly download cap; low-allowance warning not affecting the exit code; unreachable server; JSON shape; and no duplicate error line on stderr.

The exhausted-allowance cases also assert that `auth` is still reported `ok` — one failure must not hide the checks that passed.

`gofmt`, `go vet ./...`, `go test ./...`, `npm test` and `node scripts/validate-index-json.mjs .` all clean on Windows. `docs/CLI.md` gains an `aispace doctor` section with the exit-code table.
