### PR TITLE
fix: --json ignored after a failed flag parse, plus tree-wide error contract tests

### DIFF
--- a/cmd/error_contract_test.go
+++ b/cmd/error_contract_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aispace-sh/aispace-client/internal/config"
+)
+
+// errorEnvelope is the documented shape of a --json failure. Decoding into a
+// struct rather than a map is deliberate: a renamed field fails here instead of
+// being silently absent.
+type errorEnvelope struct {
+	Error struct {
+		Code       string          `json:"code"`
+		Message    string          `json:"message"`
+		Status     int             `json:"status,omitempty"`
+		Details    json.RawMessage `json:"details,omitempty"`
+		RetryAfter int             `json:"retry_after,omitempty"`
+		ExitCode   int             `json:"exit_code"`
+	} `json:"error"`
+}
+
+func parseEnvelope(t *testing.T, stderr string) errorEnvelope {
+	t.Helper()
+	trimmed := strings.TrimSpace(stderr)
+	if strings.Count(trimmed, "\n") != 0 {
+		t.Fatalf("stderr must be exactly one JSON object, got %d lines: %q",
+			strings.Count(trimmed, "\n")+1, stderr)
+	}
+	var e errorEnvelope
+	if err := json.Unmarshal([]byte(trimmed), &e); err != nil {
+		t.Fatalf("stderr is not the documented envelope: %v\n%q", err, stderr)
+	}
+	return e
+}
+
+// Each documented exit-code class, produced by a real command against a server
+// that returns the real status. These are the examples in docs/CLI.md, so the
+// documentation cannot drift from the envelope without failing here.
+func TestErrorEnvelopePerExitCodeClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		args     []string
+		wantExit int
+		wantCode string
+	}{
+		{
+			name:     "usage",
+			args:     []string{"upload", "-", "--expires", "not-a-duration"},
+			wantExit: ExitUsage,
+			wantCode: "usage",
+		},
+		{
+			name:     "authentication",
+			status:   http.StatusUnauthorized,
+			body:     `{"error":{"code":"invalid_key","message":"Invalid key"}}`,
+			args:     []string{"quota"},
+			wantExit: ExitAuth,
+			wantCode: "invalid_key",
+		},
+		{
+			name:     "quota",
+			status:   http.StatusPaymentRequired,
+			body:     `{"error":{"code":"quota_exceeded","message":"Account allowance exceeded"}}`,
+			args:     []string{"quota"},
+			wantExit: ExitQuota,
+			wantCode: "quota_exceeded",
+		},
+		{
+			name:     "rate limited",
+			status:   http.StatusTooManyRequests,
+			body:     `{"error":{"code":"rate_limited","message":"Too many requests"}}`,
+			args:     []string{"quota"},
+			wantExit: ExitRateLimit,
+			wantCode: "rate_limited",
+		},
+		{
+			name:     "monthly cap",
+			status:   http.StatusTooManyRequests,
+			body:     `{"error":{"code":"monthly_upload_cap","message":"Monthly upload cap reached"}}`,
+			args:     []string{"quota"},
+			wantExit: ExitRateLimit,
+			wantCode: "monthly_upload_cap",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			isolate(t)
+			f := newFakeServer(t)
+			writeConfig(t, config.File{Key: f.key, URL: f.srv.URL})
+			if c.status != 0 {
+				f.fail = func(*http.Request) (int, string) { return c.status, c.body }
+			}
+
+			args := append(append([]string{}, c.args...), "--json")
+			r := run("", args...)
+
+			if r.code != c.wantExit {
+				t.Fatalf("exit = %d, want %d: %+v", r.code, c.wantExit, r)
+			}
+			if r.stdout != "" {
+				t.Errorf("stdout must stay empty in --json mode, got %q", r.stdout)
+			}
+			e := parseEnvelope(t, r.stderr)
+			if e.Error.Code != c.wantCode {
+				t.Errorf("code = %q, want %q", e.Error.Code, c.wantCode)
+			}
+			if e.Error.ExitCode != c.wantExit {
+				t.Errorf("exit_code = %d but the process exited %d; a caller reading either must get the same answer",
+					e.Error.ExitCode, c.wantExit)
+			}
+			if e.Error.Message == "" {
+				t.Error("message must never be empty")
+			}
+			if c.status != 0 && e.Error.Status != c.status {
+				t.Errorf("status = %d, want %d", e.Error.Status, c.status)
+			}
+		})
+	}
+}
+
+// leafCommands returns every runnable command, so a contract is checked against
+// all of them rather than the handful a test author happened to think of.
+func leafCommands(t *testing.T) []*cobra.Command {
+	t.Helper()
+	var leaves []*cobra.Command
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		subs := c.Commands()
+		runnable := true
+		for _, sub := range subs {
+			if sub.Name() == "help" {
+				continue
+			}
+			runnable = false
+			walk(sub)
+		}
+		if runnable && c.Runnable() && c.Name() != "help" {
+			leaves = append(leaves, c)
+		}
+	}
+	walk((&app{}).newRootCmd())
+	if len(leaves) < 20 {
+		t.Fatalf("only found %d commands; the walk is wrong", len(leaves))
+	}
+	return leaves
+}
+
+func commandPath(c *cobra.Command) []string {
+	parts := strings.Fields(c.CommandPath())
+	return parts[1:] // drop the root name
+}
+
+// An unrecognised flag is a usage error on every command. This is checked by
+// walking the tree so a new command cannot quietly return a different code:
+// exit 1 would tell an agent the failure is transient and worth retrying.
+//
+// Parsing fails before RunE, so nothing here contacts a server or touches a
+// file.
+func TestUnknownFlagIsUsageErrorOnEveryCommand(t *testing.T) {
+	isolate(t)
+	for _, c := range leafCommands(t) {
+		path := commandPath(c)
+		t.Run(strings.Join(path, "/"), func(t *testing.T) {
+			r := run("", append(append([]string{}, path...), "--definitely-not-a-flag")...)
+			if r.code != ExitUsage {
+				t.Fatalf("exit = %d, want %d: %+v", r.code, ExitUsage, r)
+			}
+		})
+	}
+}
+
+// The --json failure contract, checked on every command: stdout stays empty and
+// stderr is exactly one envelope whose exit_code matches the process exit.
+func TestJSONErrorContractOnEveryCommand(t *testing.T) {
+	isolate(t)
+	for _, c := range leafCommands(t) {
+		path := commandPath(c)
+		t.Run(strings.Join(path, "/"), func(t *testing.T) {
+			r := run("", append(append([]string{}, path...), "--definitely-not-a-flag", "--json")...)
+			if r.code == ExitOK {
+				t.Fatalf("expected a failure, got %+v", r)
+			}
+			if r.stdout != "" {
+				t.Errorf("stdout must stay empty in --json mode, got %q", r.stdout)
+			}
+			e := parseEnvelope(t, r.stderr)
+			if e.Error.ExitCode != r.code {
+				t.Errorf("exit_code = %d but the process exited %d", e.Error.ExitCode, r.code)
+			}
+			if e.Error.Code == "" || e.Error.Message == "" {
+				t.Errorf("envelope is incomplete: %q", r.stderr)
+			}
+		})
+	}
+}
+
+// The human format is the other half of the contract, and agents parse it too
+// when --json is not available on a command.
+func TestHumanErrorFormatOnEveryCommand(t *testing.T) {
+	isolate(t)
+	for _, c := range leafCommands(t) {
+		path := commandPath(c)
+		t.Run(strings.Join(path, "/"), func(t *testing.T) {
+			r := run("", append(append([]string{}, path...), "--definitely-not-a-flag")...)
+			if !strings.HasPrefix(r.stderr, "error: ") {
+				t.Fatalf("stderr must start with %q: %q", "error: ", r.stderr)
+			}
+			if !strings.Contains(r.stderr, "(usage)") {
+				t.Fatalf("stderr must end with the code in parentheses: %q", r.stderr)
+			}
+		})
+	}
+}
+
+// Flag parsing stops at the first unrecognised argument, so --json written
+// after a typo was never reached and the error came out in human form. The docs
+// put --json last in every example, so that is the order agents copy -- and the
+// failure they cannot parse is exactly the one they need to read.
+func TestJSONIsHonouredRegardlessOfFlagOrder(t *testing.T) {
+	isolate(t)
+	cases := []struct {
+		name     string
+		args     []string
+		wantJSON bool
+	}{
+		{"json after the bad flag", []string{"quota", "--bogus", "--json"}, true},
+		{"json before the bad flag", []string{"quota", "--json", "--bogus"}, true},
+		{"explicit --json=true", []string{"quota", "--bogus", "--json=true"}, true},
+		{"explicit --json=false is respected", []string{"quota", "--bogus", "--json=false"}, false},
+		{"no --json at all", []string{"quota", "--bogus"}, false},
+		{"after -- it is positional, not a flag", []string{"upload", "--", "--json"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := run("", c.args...)
+			if r.code == ExitOK {
+				t.Fatalf("expected a failure: %+v", r)
+			}
+			isJSON := strings.HasPrefix(strings.TrimSpace(r.stderr), "{")
+			if isJSON != c.wantJSON {
+				t.Fatalf("json=%v, want %v: %q", isJSON, c.wantJSON, r.stderr)
+			}
+			if c.wantJSON {
+				if e := parseEnvelope(t, r.stderr); e.Error.ExitCode != r.code {
+					t.Fatalf("exit_code = %d, process exited %d", e.Error.ExitCode, r.code)
+				}
+			} else if !strings.HasPrefix(r.stderr, "error: ") {
+				t.Fatalf("want the human format: %q", r.stderr)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,12 @@ func (e *codedError) Unwrap() error { return e.err }
 func Run(args []string, stdin io.Reader, stdout, stderr io.Writer, version string) int {
 	a := &app{version: version, stdin: stdin, stdout: stdout, stderr: stderr}
 	root := a.newRootCmd()
+	// Seed --json from the raw arguments. Flag parsing stops at the first thing
+	// it does not recognise, so a typo before --json would otherwise leave the
+	// error in human form -- defeating the one flag whose purpose is that
+	// failures stay machine-readable. A successful parse overwrites this with
+	// the real value, so an explicit --json=false still wins.
+	a.jsonOut = jsonRequested(args)
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
@@ -182,6 +188,27 @@ func (a *app) newRootCmd() *cobra.Command {
 	// unaffected, so dynamic completion keeps working.
 	root.CompletionOptions.DisableDefaultCmd = true
 	return root
+}
+
+// jsonRequested reports whether --json appears in args, without relying on flag
+// parsing having succeeded. Arguments after a bare "--" are positional, so they
+// are not considered.
+func jsonRequested(args []string) bool {
+	requested := false
+	for _, arg := range args {
+		switch {
+		case arg == "--":
+			return requested
+		case arg == "--json":
+			requested = true
+		case strings.HasPrefix(arg, "--json="):
+			// pflag accepts --json=false; honour it rather than assuming true.
+			requested = strings.EqualFold(arg[len("--json="):], "true") ||
+				arg[len("--json="):] == "1" ||
+				strings.EqualFold(arg[len("--json="):], "t")
+		}
+	}
+	return requested
 }
 
 // minArgs is cobra.MinimumNArgs but yields a usage error (exit 2).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -94,6 +94,24 @@ the API's code and message together with the exit code, so a caller can branch o
 
 `details` and `retry_after` are included when the server supplies them.
 
+One sanitized example per exit-code class. These are produced by the tests in
+`cmd/error_contract_test.go`, so they cannot drift from what the binary emits:
+
+```json
+{"error":{"code":"usage","exit_code":2,"message":"--expires: invalid duration \"nope\" (try 30m, 24h, 7d)"}}
+{"error":{"code":"invalid_key","exit_code":3,"message":"Invalid key","status":401}}
+{"error":{"code":"quota_exceeded","exit_code":4,"message":"Account allowance exceeded","status":402}}
+{"error":{"code":"rate_limited","exit_code":5,"message":"Too many requests","status":429}}
+{"error":{"code":"monthly_upload_cap","exit_code":5,"message":"Monthly upload cap reached","status":429}}
+```
+
+`status` is absent when no HTTP response was involved, as in the usage example above. `exit_code`
+always matches the process exit status, so a caller can branch on whichever it already has.
+
+`--json` is honoured wherever it appears, including after a flag that fails to parse: an
+unrecognised flag stops parsing, and reporting that failure in human form would defeat the one flag
+whose purpose is that errors stay machine-readable. `--json=false` still disables it.
+
 ## Exit codes
 
 | Code | Meaning | Typical cause |


### PR DESCRIPTION
Covers the "Now" roadmap item *"Keep CLI output, JSON shapes, errors, and exit codes stable and documented"*, and the prepared **"Add a JSON contract example for every exit-code class"** draft — plus a bug the tests found while being written.

## The bug

Flag parsing stops at the first argument it does not recognise, so `--json` written *after* a typo is never reached:

```
$ aispace quota --bogus --json
error: unknown flag: --bogus (see `aispace quota --help`) (usage)

$ aispace quota --json --bogus
{"error":{"code":"usage","exit_code":2,"message":"unknown flag: --bogus ..."}}
```

Same command, same failure, **two different formats depending on argument order**.

Why it matters more than it looks: every example in the documentation writes `--json` last — `aispace quota --json`, `aispace ls --json` — so that is the order callers copy. A machine reader that mistypes another flag then gets output it cannot parse. That is precisely the case `--json` exists for: the error it most needs to read is the one it cannot.

`Run` now seeds the flag from the raw arguments before handing them to cobra. A successful parse overwrites it with the real value, so `--json=false` still disables JSON, and arguments after a bare `--` are positional and ignored. Six cases pin that.

## How it was found

By writing contract tests that **walk the command tree** rather than checking a handful of commands by hand. All 38 leaf commands, every time:

| Test | Contract |
|---|---|
| `TestUnknownFlagIsUsageErrorOnEveryCommand` | an unrecognised flag is exit `2` everywhere |
| `TestJSONErrorContractOnEveryCommand` | stdout empty, stderr exactly one envelope, `exit_code` == process exit |
| `TestHumanErrorFormatOnEveryCommand` | `error: <message> (<code>)` |
| `TestErrorEnvelopePerExitCodeClass` | one real failure per documented class, 2 through 5 |

The first of those would have caught #32 (missing required flag exiting 1). The second caught this one. That is the argument for walking the tree: both bugs were in commands nobody would have picked for a hand-written test.

Two deliberate details:

- **The walks are side-effect free.** Parsing fails before `RunE`, so nothing contacts a server or touches a file — which is what makes it safe to run every command indiscriminately.
- **The envelope is decoded into a struct, not a map.** A renamed field fails the test instead of silently reading as absent, which is the failure mode that lets a documented shape rot.

`leafCommands` also asserts it found at least 20 commands, so a broken walk fails loudly rather than passing vacuously over an empty list.

## Documentation

`docs/CLI.md` gains one sanitized example per exit-code class, taken from those tests so the two cannot drift:

```json
{"error":{"code":"usage","exit_code":2,"message":"--expires: invalid duration \"nope\" (try 30m, 24h, 7d)"}}
{"error":{"code":"invalid_key","exit_code":3,"message":"Invalid key","status":401}}
{"error":{"code":"quota_exceeded","exit_code":4,"message":"Account allowance exceeded","status":402}}
{"error":{"code":"rate_limited","exit_code":5,"message":"Too many requests","status":429}}
{"error":{"code":"monthly_upload_cap","exit_code":5,"message":"Monthly upload cap reached","status":429}}
```

No credential, endpoint, file ID or private link appears in any of them, and `status` is correctly absent from the usage example where no HTTP response was involved.

## A note on the draft

This overlaps the `good first issue` draft of the same name. I have deliberately **not** touched the other two drafts (GitLab CI example, npm unsupported-platform coverage) so they stay available for a first-time contributor — and if you would rather keep this one for that too, close this and I will resubmit just the `--json` ordering fix on its own.

`gofmt`, `go vet ./...`, `go test ./...`, `npm test` and `node scripts/validate-index-json.mjs .` clean on Windows. Independent of #31 and #32.
